### PR TITLE
Native (iOS): Fix `availableZoneIds` having non-available ids

### DIFF
--- a/core/commonTest/src/TimeZoneTest.kt
+++ b/core/commonTest/src/TimeZoneTest.kt
@@ -36,6 +36,13 @@ class TimeZoneTest {
     }
 
     @Test
+    fun availableZonesAreAvailable() {
+        for (zoneName in TimeZone.availableZoneIds) {
+            TimeZone.of(zoneName)
+        }
+    }
+
+    @Test
     fun of() {
         val tzm = TimeZone.of("Europe/Moscow")
         assertNotNull(tzm)

--- a/core/nativeMain/cinterop/cpp/windows.cpp
+++ b/core/nativeMain/cinterop/cpp/windows.cpp
@@ -281,7 +281,6 @@ char * get_system_timezone()
 char ** available_zone_ids()
 {
     std::set<std::string> known_native_names, known_ids;
-    known_ids.insert("UTC");
     DYNAMIC_TIME_ZONE_INFORMATION dtzi{};
     for (DWORD dwResult = 0, i = 0; dwResult != ERROR_NO_MORE_ITEMS; ++i) {
         dwResult = EnumDynamicTimeZoneInformation(i, &dtzi);

--- a/core/nativeMain/src/TimeZone.kt
+++ b/core/nativeMain/src/TimeZone.kt
@@ -62,7 +62,7 @@ public actual open class TimeZone internal constructor(actual val id: String) {
 
         actual val availableZoneIds: Set<String>
             get() {
-                val set = mutableSetOf<String>()
+                val set = mutableSetOf<String>("UTC")
                 val zones = available_zone_ids()
                     ?: throw RuntimeException("Failed to get the list of available timezones")
                 var ptr = zones


### PR DESCRIPTION
There were actually two bugs:
* First, contrary to the expectations, `timeZoneWithName` does not
  resolve timezone name abbreviations on its own. They should be
  checked manually.
* Second, contrary to the expectations, `abbreviationDictionary`
  has abbreviations for timezones that are not even available!

Both are fixed.