### PR TITLE
Native (all): Make parsing less forgiving

### DIFF
--- a/core/commonTest/src/LocalDateTest.kt
+++ b/core/commonTest/src/LocalDateTest.kt
@@ -42,6 +42,11 @@ class LocalDateTest {
         checkParsedComponents("2019-10-01", 2019, 10, 1, 2, 274)
         checkParsedComponents("2016-02-29", 2016, 2, 29, 1, 60)
         checkParsedComponents("2017-10-01", 2017, 10, 1,  7, 274)
+        assertFailsWith<Throwable> { LocalDate.parse("102017-10-01") }
+        assertFailsWith<Throwable> { LocalDate.parse("2017--10-01") }
+        assertFailsWith<Throwable> { LocalDate.parse("2017-+10-01") }
+        assertFailsWith<Throwable> { LocalDate.parse("2017-10-+01") }
+        assertFailsWith<Throwable> { LocalDate.parse("2017-10--01") }
     }
 
     @Test

--- a/core/nativeMain/src/LocalDate.kt
+++ b/core/nativeMain/src/LocalDate.kt
@@ -13,7 +13,7 @@ import kotlin.math.*
 // This is a function and not a value due to https://github.com/Kotlin/kotlinx-datetime/issues/5
 // org.threeten.bp.format.DateTimeFormatter#ISO_LOCAL_DATE
 internal val localDateParser: Parser<LocalDate>
-    get() = intParser(4, 10)
+    get() = intParser(4, 10, SignStyle.EXCEEDS_PAD)
         .chainIgnoring(concreteCharParser('-'))
         .chain(intParser(2, 2))
         .chainIgnoring(concreteCharParser('-'))


### PR DESCRIPTION
Before, some strings could be parsed on Native but not on other
platforms: in particular, every numeric field could be prefixed
with a plus sign.