### PR TITLE
Common: TimeZone.SYSTEM -> TimeZone.currentSystemDefault()

### DIFF
--- a/core/commonMain/src/TimeZone.kt
+++ b/core/commonMain/src/TimeZone.kt
@@ -13,7 +13,7 @@ public expect open class TimeZone {
          * @throws RuntimeException if the name of the system time-zone is invalid or the time-zone specified as the
          * system one cannot be found.
          */
-        val SYSTEM: TimeZone
+        fun currentSystemDefault(): TimeZone
         val UTC: TimeZone
 
         /**

--- a/core/commonTest/src/InstantTest.kt
+++ b/core/commonTest/src/InstantTest.kt
@@ -50,7 +50,7 @@ class InstantTest {
     fun instantToLocalDTConversion() {
         val now = Clock.System.now()
         println(now.toLocalDateTime(TimeZone.UTC))
-        println(now.toLocalDateTime(TimeZone.SYSTEM))
+        println(now.toLocalDateTime(TimeZone.currentSystemDefault()))
     }
 
     /* Based on the ThreeTenBp project.
@@ -164,8 +164,8 @@ class InstantTest {
             val instant1 = Instant.fromEpochMilliseconds(millis1)
             val instant2 = Instant.fromEpochMilliseconds(millis2)
 
-            val diff = instant1.periodUntil(instant2, TimeZone.SYSTEM)
-            val instant3 = instant1.plus(diff, TimeZone.SYSTEM)
+            val diff = instant1.periodUntil(instant2, TimeZone.currentSystemDefault())
+            val instant3 = instant1.plus(diff, TimeZone.currentSystemDefault())
 
             if (instant2 != instant3)
                 println("start: $instant1, end: $instant2, start + diff: $instant3, diff: $diff")

--- a/core/commonTest/src/LocalDateTest.kt
+++ b/core/commonTest/src/LocalDateTest.kt
@@ -71,7 +71,7 @@ class LocalDateTest {
 
     @Test
     fun tomorrow() {
-        val today = Clock.System.todayAt(TimeZone.SYSTEM)
+        val today = Clock.System.todayAt(TimeZone.currentSystemDefault())
 
         val nextMonthPlusDay1 = today.plus(DateTimeUnit.MONTH).plus(1, DateTimeUnit.DAY)
         val nextMonthPlusDay2 = today + DatePeriod(months = 1, days = 1)

--- a/core/commonTest/src/LocalDateTimeTest.kt
+++ b/core/commonTest/src/LocalDateTimeTest.kt
@@ -61,7 +61,7 @@ class LocalDateTimeTest {
 
     @Test
     fun getCurrentHMS() {
-        with(Clock.System.now().toLocalDateTime(TimeZone.SYSTEM)) {
+        with(Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())) {
             println("${hour}h ${minute}m")
         }
     }

--- a/core/commonTest/src/TimeZoneTest.kt
+++ b/core/commonTest/src/TimeZoneTest.kt
@@ -20,7 +20,11 @@ class TimeZoneTest {
 
     @Test
     fun system() {
-        println(TimeZone.SYSTEM)
+        val tz = TimeZone.currentSystemDefault()
+        println(tz)
+        val offset = Clock.System.now().offsetAt(tz)
+        assertTrue(offset.totalSeconds in -18 * 60 * 60 .. 18 * 60 * 60)
+        // assertTrue(tz.id.contains('/')) // does not work on build agents, whose timezone is "UTC"
         // TODO: decide how to assert system tz properties
     }
 
@@ -31,7 +35,7 @@ class TimeZoneTest {
         allTzIds.forEach(::println)
 
         assertNotEquals(0, allTzIds.size)
-        assertTrue(TimeZone.SYSTEM.id in allTzIds)
+        assertTrue(TimeZone.currentSystemDefault().id in allTzIds)
         assertTrue("UTC" in allTzIds)
     }
 

--- a/core/jsMain/src/TimeZone.kt
+++ b/core/jsMain/src/TimeZone.kt
@@ -24,7 +24,7 @@ actual open class TimeZone internal constructor(internal val zoneId: ZoneId) {
     override fun toString(): String = zoneId.toString()
 
     actual companion object {
-        actual val SYSTEM: TimeZone = ZoneId.systemDefault().let(::TimeZone)
+        actual fun currentSystemDefault(): TimeZone = ZoneId.systemDefault().let(::TimeZone)
         actual val UTC: TimeZone = jtZoneOffset.UTC.let(::TimeZone)
         actual fun of(zoneId: String): TimeZone = ZoneId.of(zoneId).let(::TimeZone)
         actual val availableZoneIds: Set<String> get() = ZoneId.getAvailableZoneIds().toSet()

--- a/core/jvmMain/src/TimeZone.kt
+++ b/core/jvmMain/src/TimeZone.kt
@@ -25,7 +25,7 @@ actual open class TimeZone internal constructor(internal val zoneId: ZoneId) {
     override fun toString(): String = zoneId.toString()
 
     actual companion object {
-        actual val SYSTEM: TimeZone = ZoneId.systemDefault().let(::TimeZone)
+        actual fun currentSystemDefault(): TimeZone = ZoneId.systemDefault().let(::TimeZone)
         actual val UTC: TimeZone = jtZoneOffset.UTC.let(::TimeZone)
         actual fun of(zoneId: String): TimeZone = ZoneId.of(zoneId).let(::TimeZone)
         actual val availableZoneIds: Set<String> get() = ZoneId.getAvailableZoneIds()

--- a/core/nativeMain/cinterop/cpp/apple.mm
+++ b/core/nativeMain/cinterop/cpp/apple.mm
@@ -73,16 +73,58 @@ extern "C" {
 
 char * get_system_timezone(TZID *tzid)
 {
-    CFTimeZoneRef zone = CFTimeZoneCopySystem(); // always succeeds
-    auto name = CFTimeZoneGetName(zone);
-    *tzid = id_by_name((__bridge NSString *)name);
-    CFIndex bufferSize = CFStringGetLength(name) + 1;
-    char * buffer = check_allocation((char *)malloc(sizeof(char) * bufferSize));
-    // only fails if the name is not UTF8-encoded, which is an anomaly.
-    auto result = CFStringGetCString(name, buffer, bufferSize, kCFStringEncodingUTF8);
-    assert(result);
-    CFRelease(zone);
-    return buffer;
+    /* The framework has its own cache of the system timezone. Calls to
+    [NSTimeZone systemTimeZone] do not reflect changes to the system timezone
+    and instead just return the cached value. Thus, to acquire the current
+    system timezone, first, the cache should be cleared.
+
+    This solution is not without flaws, however. In particular, resetting the
+    system timezone also resets the default timezone ([NSTimeZone default]) if
+    it's the same as the cached system timezone:
+
+        NSTimeZone.defaultTimeZone = [NSTimeZone
+            timeZoneWithName: [[NSTimeZone systemTimeZone] name]];
+        NSLog(@"%@", NSTimeZone.defaultTimeZone.name);
+        NSLog(@"Change the system time zone, then press Enter");
+        getchar();
+        [NSTimeZone resetSystemTimeZone];
+        NSLog(@"%@", NSTimeZone.defaultTimeZone.name); // will also change
+
+    This is a fairly marginal problem:
+        * It is only a problem when the developer deliberately sets the default
+          timezone to the region that just happens to be the one that the user
+          is in, and then the user moves to another region, and the app also
+          uses the system timezone.
+        * Since iOS 11, the significance of the default timezone has been
+          de-emphasized. In particular, it is not included in the API for
+          Swift: https://forums.swift.org/t/autoupdating-type-properties/4608/4
+
+    Another possible solution could involve using [NSTimeZone localTimeZone].
+    This is documented to reflect the current, uncached system timezone on
+    iOS 11 and later:
+    https://developer.apple.com/documentation/foundation/nstimezone/1387209-localtimezone
+    However:
+        * Before iOS 11, this was the same as the default timezone and did not
+          reflect the system timezone.
+        * Worse, on a Mac (10.15.5), I failed to get it to work as documented.
+              NSLog(@"%@", NSTimeZone.localTimeZone.name);
+              NSLog(@"Change the system time zone, then press Enter");
+              getchar();
+              // [NSTimeZone resetSystemTimeZone]; // uncomment to make it work
+              NSLog(@"%@", NSTimeZone.localTimeZone.name);
+          The printed strings are the same even if I wait for good 10 minutes
+          before pressing Enter, unless the line with "reset" is uncommented--
+          then the timezone is updated, as it should be. So, for some reason,
+          NSTimeZone.localTimeZone, too, is cached.
+          With no iOS device to test this on, it doesn't seem worth the effort
+          to avoid just resetting the system timezone due to one edge case
+          that's hard to avoid.
+    */
+    [NSTimeZone resetSystemTimeZone];
+    NSTimeZone *zone = [NSTimeZone systemTimeZone];
+    NSString *name = [zone name];
+    *tzid = id_by_name(name);
+    return strdup([name UTF8String]);
 }
 
 char ** available_zone_ids()

--- a/core/nativeMain/src/TimeZone.kt
+++ b/core/nativeMain/src/TimeZone.kt
@@ -16,8 +16,7 @@ public actual open class TimeZone internal constructor(private val tzid: TZID, a
 
     actual companion object {
 
-        @SharedImmutable
-        actual val SYSTEM: TimeZone = memScoped {
+        actual fun currentSystemDefault(): TimeZone = memScoped {
             val tzid = alloc<TZIDVar>()
             val string = get_system_timezone(tzid.ptr)
                 ?: throw RuntimeException("Failed to get the system timezone.")


### PR DESCRIPTION
In addition to the renaming, caching of the system timezone was
disabled. Before, due to querying the timezone being an expensive
operation (especially on Native), we acquired the system timezone
only once. The main motivation behind it was that having an
expensive operation on a `val` was against the expectations of
users, and most JRE implementations do not update the system
timezone.

However, it turned out that at least on Android the changes to
system timezone are tracked by the Java runtime, so it is not
viable to just assume that the system timezone won't change. Thus,
we decided to perform the renaming and thus communitate that the
operation may be an expensive one.