### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,9 @@ The library depends on the Kotlin Standard Library not lower than `1.4.0`.
 
 ```kotlin
 repositories {
-    maven(url = "https://kotlin.bintray.com/kotlinx/") // soon will be just jcenter()
+    maven {
+            url 'https://kotlin.bintray.com/kotlinx/'
+        }    // soon will be just jcenter()
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -255,11 +255,25 @@ The library depends on the Kotlin Standard Library not lower than `1.4.0`.
 - Add the bintray repository:
 
 ```kotlin
+
+Groovy  DSL
+
 repositories {
     maven {
             url 'https://kotlin.bintray.com/kotlinx/'
-        }    // soon will be just jcenter()
+        }   
+}   // soon will be just jcenter()
+
+
+kotlin  DSL
+
+repositories {
+    maven(url = "https://kotlin.bintray.com/kotlinx/") // soon will be just jcenter()
 }
+
+
+
+
 ```
 
 - In multiplatform projects, add a dependency to the commonMain source set dependencies


### PR DESCRIPTION
Modify the maven dependency error report,
Could not set unknown property'url' for repository container of type org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler.