### PR TITLE
Native (iOS): fix crash when getting the current time

### DIFF
--- a/core/commonTest/src/LocalDateTimeTest.kt
+++ b/core/commonTest/src/LocalDateTimeTest.kt
@@ -72,7 +72,6 @@ class LocalDateTimeTest {
         }
     }
 
-
     @OptIn(ExperimentalTime::class)
     @Test
     fun tomorrow() {

--- a/core/nativeMain/cinterop/cpp/apple.mm
+++ b/core/nativeMain/cinterop/cpp/apple.mm
@@ -81,6 +81,16 @@ static NSTimeZone *timezone_by_id(TZID id)
 
 extern "C" {
 
+bool current_time(int64_t *sec, int32_t *nano)
+{
+    double current = NSDate.date.timeIntervalSince1970;
+    double dsec;
+    double dnano = modf(current, &dsec);
+    *sec = (int64_t)dsec;
+    *nano = (int32_t)(dnano * 1000000000);
+    return true;
+}
+
 char * get_system_timezone(TZID *tzid)
 {
     /* The framework has its own cache of the system timezone. Calls to

--- a/core/nativeMain/cinterop/cpp/cdate.cpp
+++ b/core/nativeMain/cinterop/cpp/cdate.cpp
@@ -81,6 +81,18 @@ static TZID id_by_zone(const tzdb& db, const time_zone* tz)
 
 extern "C" {
 
+bool current_time(int64_t *sec, int32_t *nano)
+{
+    timespec tm;
+    int error = clock_gettime(CLOCK_REALTIME, &tm);
+    if (error) {
+        return false;
+    }
+    *sec = tm.tv_sec;
+    *nano = tm.tv_nsec;
+    return true;
+}
+
 char * get_system_timezone(TZID * id)
 {
     try {

--- a/core/nativeMain/cinterop/cpp/windows.cpp
+++ b/core/nativeMain/cinterop/cpp/windows.cpp
@@ -281,6 +281,18 @@ static int offset_at_systime(DYNAMIC_TIME_ZONE_INFORMATION& dtzi,
 
 extern "C" {
 
+bool current_time(int64_t *sec, int32_t *nano)
+{
+    timespec tm;
+    int error = clock_gettime(CLOCK_REALTIME, &tm);
+    if (error) {
+        return false;
+    }
+    *sec = tm.tv_sec;
+    *nano = tm.tv_nsec;
+    return true;
+}
+
 char * get_system_timezone(TZID* id)
 {
     DYNAMIC_TIME_ZONE_INFORMATION dtzi{};

--- a/core/nativeMain/cinterop/public/cdate.h
+++ b/core/nativeMain/cinterop/public/cdate.h
@@ -6,6 +6,7 @@
 #pragma once
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 typedef size_t TZID;
 const TZID TZID_INVALID = SIZE_MAX;
@@ -14,6 +15,9 @@ enum GAP_HANDLING {
     GAP_HANDLING_MOVE_FORWARD,
     GAP_HANDLING_NEXT_CORRECT,
 };
+
+// Returns true if successful.
+bool current_time(int64_t *sec, int32_t *nano);
 
 /* Returns a string that must be freed by the caller, or null.
    If something is returned, `id` has the id of the timezone. */

--- a/core/nativeMain/cinterop_actuals/TimeZoneNative.kt
+++ b/core/nativeMain/cinterop_actuals/TimeZoneNative.kt
@@ -16,6 +16,9 @@ internal actual fun getCurrentSystemDefaultTimeZone(): TimeZone = memScoped {
     TimeZone(tzid.value, kotlinString)
 }
 
+internal actual fun current_time(sec: kotlinx.cinterop.CValuesRef<platform.posix.int64_tVar /* = kotlinx.cinterop.LongVarOf<kotlin.Long> */>?, nano: kotlinx.cinterop.CValuesRef<platform.posix.int32_tVar>?): kotlin.Boolean =
+    kotlinx.datetime.internal.current_time(sec, nano)
+
 internal actual fun available_zone_ids(): kotlinx.cinterop.CPointer<kotlinx.cinterop.CPointerVar<kotlinx.cinterop.ByteVar>>? =
         kotlinx.datetime.internal.available_zone_ids()
 

--- a/core/nativeMain/src/TimeZone.kt
+++ b/core/nativeMain/src/TimeZone.kt
@@ -22,6 +22,7 @@ internal expect fun offset_at_datetime(zone: kotlinx.datetime.TZID /* = kotlin.U
 internal expect fun at_start_of_day(zone: kotlinx.datetime.TZID /* = kotlin.ULong */, epoch_sec: platform.posix.int64_t /* = kotlin.Long */): kotlin.Long
 internal expect fun offset_at_instant(zone: kotlinx.datetime.TZID /* = kotlin.ULong */, epoch_sec: platform.posix.int64_t /* = kotlin.Long */): kotlin.Int
 internal expect fun timezone_by_name(zone_name: kotlin.String?): kotlinx.datetime.TZID /* = kotlin.ULong */
+internal expect fun current_time(sec: kotlinx.cinterop.CValuesRef<platform.posix.int64_tVar /* = kotlinx.cinterop.LongVarOf<kotlin.Long> */>?, nano: kotlinx.cinterop.CValuesRef<platform.posix.int32_tVar>?): kotlin.Boolean
 
 public actual open class TimeZone internal constructor(private val tzid: TZID, actual val id: String) {
 
@@ -92,7 +93,7 @@ public actual open class TimeZone internal constructor(private val tzid: TZID, a
 
     internal open fun offsetAtImpl(instant: Instant): ZoneOffset {
         val offset = offset_at_instant(tzid, instant.epochSeconds)
-        if (offset == INT_MAX) {
+        if (offset == Int.MAX_VALUE) {
             throw RuntimeException("Unable to acquire the offset at instant $instant for zone $this")
         }
         return ZoneOffset.ofSeconds(offset)
@@ -113,9 +114,9 @@ public actual open class TimeZone internal constructor(private val tzid: TZID, a
     internal open fun LocalDateTime.atZone(preferred: ZoneOffset? = null): ZonedDateTime = memScoped {
         val epochSeconds = toEpochSecond(ZoneOffset.UTC)
         val offset = alloc<IntVar>()
-        offset.value = preferred?.totalSeconds ?: INT_MAX
+        offset.value = preferred?.totalSeconds ?: Int.MAX_VALUE
         val transitionDuration = offset_at_datetime(tzid, epochSeconds, offset.ptr)
-        if (offset.value == INT_MAX) {
+        if (offset.value == Int.MAX_VALUE) {
             throw RuntimeException("Unable to acquire the offset at ${this@atZone} for zone ${this@TimeZone}")
         }
         val dateTime = try {


### PR DESCRIPTION
The root cause is unclear as of yet, but this workaround should do.