### PR TITLE
Publication to Maven Central

### DIFF
--- a/.teamcity/additionalConfiguration.kt
+++ b/.teamcity/additionalConfiguration.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.Project
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+
+fun Project.additionalConfiguration() {
+    knownBuilds.buildAll.features {
+        commitStatusPublisher {
+            publisher = github {
+                githubUrl = "https://api.github.com"
+                authType = personalToken {
+                    token = "credentialsJSON:af36802a-ccd4-401b-86b9-0b08d2dfad17"
+                }
+            }
+            param("github_oauth_user", "ilya-g")
+        }
+    }
+}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -142,6 +142,8 @@ fun Project.deployVersion() = BuildType {
     params {
         // enable editing of this configuration to set up things
         param("teamcity.ui.settings.readOnly", "false")
+        param("bintray-user", bintrayUserName)
+        password("bintray-key", bintrayToken)
         param(versionSuffixParameter, "dev-%build.counter%")
         param("reverse.dep.$BUILD_CREATE_STAGING_REPO_ABSOLUTE_ID.system.libs.repo.description", libraryStagingRepoDescription)
         param("env.libs.repository.id", "%dep.$BUILD_CREATE_STAGING_REPO_ABSOLUTE_ID.env.libs.repository.id%")
@@ -156,7 +158,7 @@ fun Project.deployVersion() = BuildType {
         gradle {
             name = "Verify Gradle Configuration"
             tasks = "clean publishPrepareVersion"
-            gradleParams = "--info --stacktrace -P$versionSuffixParameter=%$versionSuffixParameter% -P$releaseVersionParameter=%$releaseVersionParameter%"
+            gradleParams = "--info --stacktrace -P$versionSuffixParameter=%$versionSuffixParameter% -P$releaseVersionParameter=%$releaseVersionParameter% -PbintrayApiKey=%bintray-key% -PbintrayUser=%bintray-user%"
             buildFile = ""
             jdkHome = "%env.$jdk%"
         }
@@ -186,6 +188,8 @@ fun Project.deploy(platform: Platform, configureBuild: BuildType) = buildType("D
     params {
         param(versionSuffixParameter, "${configureBuild.depParamRefs[versionSuffixParameter]}")
         param(releaseVersionParameter, "${configureBuild.depParamRefs[releaseVersionParameter]}")
+        param("bintray-user", bintrayUserName)
+        password("bintray-key", bintrayToken)
         param("env.libs.repository.id", "%dep.$BUILD_CREATE_STAGING_REPO_ABSOLUTE_ID.env.libs.repository.id%")
     }
 
@@ -198,7 +202,7 @@ fun Project.deploy(platform: Platform, configureBuild: BuildType) = buildType("D
             name = "Deploy ${platform.buildTypeName()} Binaries"
             jdkHome = "%env.$jdk%"
             jvmArgs = "-Xmx1g"
-            gradleParams = "--info --stacktrace -P$versionSuffixParameter=%$versionSuffixParameter% -P$releaseVersionParameter=%$releaseVersionParameter%"
+            gradleParams = "--info --stacktrace -P$versionSuffixParameter=%$versionSuffixParameter% -P$releaseVersionParameter=%$releaseVersionParameter% -PbintrayApiKey=%bintray-key% -PbintrayUser=%bintray-user%"
             tasks = "clean publish"
             buildFile = ""
             gradleWrapperPath = ""

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -202,7 +202,7 @@ fun Project.deployVersion() = BuildType {
         gradle {
             name = "Verify Gradle Configuration"
             tasks = "clean publishPrepareVersion"
-            gradleParams = "--info --stacktrace -P$versionSuffixParameter=%$versionSuffixParameter% -P$releaseVersionParameter=%$releaseVersionParameter% -PbintrayApiKey=%bintray-key% -PbintrayUser=%bintray-user%"
+            gradleParams = "--info --stacktrace -P$versionSuffixParameter=%$versionSuffixParameter% -P$releaseVersionParameter=%$releaseVersionParameter%"
             buildFile = ""
             jdkHome = "%env.$jdk%"
         }
@@ -244,7 +244,7 @@ fun Project.deploy(platform: Platform, configureBuild: BuildType) = buildType("D
             name = "Deploy ${platform.buildTypeName()} Binaries"
             jdkHome = "%env.$jdk%"
             jvmArgs = "-Xmx1g"
-            gradleParams = "--info --stacktrace -P$versionSuffixParameter=%$versionSuffixParameter% -P$releaseVersionParameter=%$releaseVersionParameter% -PbintrayApiKey=%bintray-key% -PbintrayUser=%bintray-user%"
+            gradleParams = "--info --stacktrace -P$versionSuffixParameter=%$versionSuffixParameter% -P$releaseVersionParameter=%$releaseVersionParameter%"
             tasks = "clean publish"
             buildFile = ""
             gradleWrapperPath = ""

--- a/.teamcity/utils.kt
+++ b/.teamcity/utils.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.*
+
+const val versionSuffixParameter = "versionSuffix"
+const val teamcitySuffixParameter = "teamcitySuffix"
+const val releaseVersionParameter = "releaseVersion"
+
+const val libraryStagingRepoDescription = "Kotlin-DateTime-library"
+
+val platforms = Platform.values()
+const val jdk = "JDK_18_x64"
+
+enum class Platform {
+    Windows, Linux, MacOS;
+}
+
+fun Platform.nativeTaskPrefix(): String = when(this) {
+    Platform.Windows -> "mingwX64"
+    Platform.Linux -> "linuxX64"
+    Platform.MacOS -> "macosX64"
+}
+fun Platform.buildTypeName(): String = when (this) {
+    Platform.Windows, Platform.Linux -> name
+    Platform.MacOS -> "Mac OS X"
+}
+fun Platform.buildTypeId(): String = buildTypeName().substringBefore(" ")
+fun Platform.teamcityAgentName(): String = buildTypeName()
+
+
+const val BUILD_CONFIGURE_VERSION_ID = "Build_Version"
+const val BUILD_ALL_ID = "Build_All"
+const val DEPLOY_CONFIGURE_VERSION_ID = "Deploy_Configure"
+const val DEPLOY_PUBLISH_ID = "Deploy_Publish"
+
+val BUILD_CREATE_STAGING_REPO_ABSOLUTE_ID = AbsoluteId("KotlinTools_CreateSonatypeStagingRepository")
+
+class KnownBuilds(private val project: Project) {
+    private fun buildWithId(id: String): BuildType {
+        return project.buildTypes.single { it.id.toString().endsWith(id) }
+    }
+
+    val buildVersion: BuildType get() = buildWithId(BUILD_CONFIGURE_VERSION_ID)
+    val buildAll: BuildType get() = buildWithId(BUILD_ALL_ID)
+    fun buildOn(platform: Platform): BuildType = buildWithId("Build_${platform.buildTypeId()}")
+    val deployVersion: BuildType get() = buildWithId(DEPLOY_CONFIGURE_VERSION_ID)
+    val deployPublish: BuildType get() = buildWithId(DEPLOY_PUBLISH_ID)
+    fun deployOn(platform: Platform): BuildType = buildWithId("Deploy_${platform.buildTypeId()}")
+}
+
+val Project.knownBuilds: KnownBuilds get() = KnownBuilds(this)
+
+
+fun Project.buildType(name: String, platform: Platform, configure: BuildType.() -> Unit) = BuildType {
+    // ID is prepended with Project ID, so don't repeat it here
+    // ID should conform to identifier rules, so just letters, numbers and underscore
+    id("${name}_${platform.buildTypeId()}")
+    // Display name of the build configuration
+    this.name = "$name (${platform.buildTypeName()})"
+
+    requirements {
+        contains("teamcity.agent.jvm.os.name", platform.teamcityAgentName())
+    }
+
+    params {
+        // This parameter is needed for macOS agent to be compatible
+        if (platform == Platform.MacOS) param("env.JDK_17", "")
+    }
+
+    commonConfigure()
+    configure()
+}.also { buildType(it) }
+
+
+fun BuildType.commonConfigure() {
+    requirements {
+        noLessThan("teamcity.agent.hardware.memorySizeMb", "6144")
+    }
+
+    // Allow to fetch build status through API for badges
+    allowExternalStatus = true
+
+    // Configure VCS, by default use the same and only VCS root from which this configuration is fetched
+    vcs {
+        root(DslContext.settingsRoot)
+        showDependenciesChanges = true
+        checkoutMode = CheckoutMode.ON_AGENT
+    }
+
+    failureConditions {
+        errorMessage = true
+        nonZeroExitCode = true
+        executionTimeoutMin = 120
+    }
+
+    features {
+        feature {
+            id = "perfmon"
+            type = "perfmon"
+        }
+    }
+}
+
+fun BuildType.dependsOn(build: IdOwner, configure: Dependency.() -> Unit) =
+        apply {
+            dependencies.dependency(build, configure)
+        }
+
+fun BuildType.dependsOnSnapshot(build: IdOwner, onFailure: FailureAction = FailureAction.FAIL_TO_START, configure: SnapshotDependency.() -> Unit = {}) = apply {
+    dependencies.dependency(build) {
+        snapshot {
+            configure()
+            onDependencyFailure = onFailure
+            onDependencyCancel = FailureAction.CANCEL
+        }
+    }
+}

--- a/.teamcity/utils.kt
+++ b/.teamcity/utils.kt
@@ -9,6 +9,8 @@ const val versionSuffixParameter = "versionSuffix"
 const val teamcitySuffixParameter = "teamcitySuffix"
 const val releaseVersionParameter = "releaseVersion"
 
+const val bintrayUserName = "%env.BINTRAY_USER%"
+const val bintrayToken = "%env.BINTRAY_API_KEY%"
 const val libraryStagingRepoDescription = "Kotlin-DateTime-library"
 
 val platforms = Platform.values()

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ The implementation of date/time types, such as `Instant`, `LocalDateTime`, `Time
 
 > Note that the library is experimental, and the API is subject to change.
 
-The library is published to [kotlinx](https://bintray.com/kotlin/kotlinx/kotlinx.datetime) bintray repository<!-- and available in jcenter as well-->.
+The library is published to Maven Central.
 
 The library depends on the Kotlin Standard Library not lower than `1.4.0`.
 
@@ -253,14 +253,6 @@ If you target Android devices running **below API 26**, you need to use Android 
 and enable [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring).
 
 ### Gradle
-
-- Add the bintray repository:
-
-```kotlin
-repositories {
-    maven(url = "https://kotlin.bintray.com/kotlinx/") // soon will be just jcenter()
-}
-```
 
 - In multiplatform projects, add a dependency to the commonMain source set dependencies
 ```kotlin
@@ -313,32 +305,7 @@ private val jsJodaTz = JsJodaTimeZoneModule
 
 ### Maven
 
-- Add the bintray repository to the `<repositories>` section.
-
-```xml
-<repository>
-    <snapshots>
-        <enabled>false</enabled>
-    </snapshots>
-    <id>kotlinx</id>
-    <name>kotlinx</name>
-    <url>https://kotlin.bintray.com/kotlinx/</url>
-</repository>
-```
-<!--
-```xml
-<repository>
-    <snapshots>
-        <enabled>false</enabled>
-    </snapshots>
-    <id>jcenter</id>
-    <name>jcenter</name>
-    <url>https://jcenter.bintray.com/</url>
-</repository>
-```
--->
-
-- Add a dependency to the `<dependencies>` element. Note that you need to use the platform-specific `-jvm` artifact in Maven.
+Add a dependency to the `<dependencies>` element. Note that you need to use the platform-specific `-jvm` artifact in Maven.
 
 ```xml
 <dependency>

--- a/README.md
+++ b/README.md
@@ -254,6 +254,14 @@ and enable [core library desugaring](https://developer.android.com/studio/write/
 
 ### Gradle
 
+- Add the Maven Central repository if it is not already there:
+
+```kotlin
+repositories {
+    mavenCentral()
+}
+```
+
 - In multiplatform projects, add a dependency to the commonMain source set dependencies
 ```kotlin
 kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,37 +8,17 @@ buildscript {
 }
 
 plugins {
-    id("kotlinx.team.infra") version "0.1.0-dev-53"
-}
-
-project(":kotlinx-datetime") {
-    pluginManager.apply("kotlin-multiplatform")
-//    pluginManager.apply("maven-publish")
+    id("kotlinx.team.infra") version "0.3.0-dev-64"
 }
 
 infra {
     teamcity {
-        bintrayUser = "%env.BINTRAY_USER%"
-        bintrayToken = "%env.BINTRAY_API_KEY%"
+        libraryStagingRepoDescription = project.name
     }
     publishing {
         include(":kotlinx-datetime")
-
-        bintray {
-            organization = "kotlin"
-            repository = "kotlinx"
-            library = "kotlinx.datetime"
-            username = findProperty("bintrayUser") as String?
-            password = findProperty("bintrayApiKey") as String?
-        }
-
-        bintrayDev {
-            organization = "kotlin"
-            repository = "kotlin-dev"
-            library = "kotlinx.datetime"
-            username = findProperty("bintrayUser") as String?
-            password = findProperty("bintrayApiKey") as String?
-        }
+        libraryRepoUrl = "https://github.com/Kotlin/kotlinx-datetime"
+        sonatype { }
     }
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,4 @@
+import kotlinx.team.infra.mavenPublicationsPom
 import java.net.URL
 import java.util.Locale
 import javax.xml.parsers.DocumentBuilderFactory
@@ -7,20 +8,16 @@ plugins {
     `maven-publish`
 }
 
+mavenPublicationsPom {
+    description.set("Kotlin Datetime Library")
+}
+
 base {
     archivesBaseName = "kotlinx-datetime" // doesn't work
 }
 
 //val JDK_6: String by project
 val JDK_8: String by project
-
-//publishing {
-//    repositories {
-//        maven(url = "${rootProject.buildDir}/maven") {
-//            this.name = "buildLocal2"
-//        }
-//    }
-//}
 
 kotlin {
     infra {


### PR DESCRIPTION
Fixes https://github.com/Kotlin/kotlinx-datetime/issues/98
Fixes https://github.com/Kotlin/kotlinx-datetime/issues/61
Fixes https://github.com/Kotlin/kotlinx-datetime/issues/40

The TeamCity config is mostly unchanged from the autogenerated version, with one notable difference: mentions of bintray are scrubbed as to avoid clutter in the TeamCity build parameter lists.