### PR TITLE
Add Dokka 1.4.30 for documentation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ buildscript {
 
 plugins {
     id("kotlinx.team.infra") version "0.3.0-dev-64"
+    id("org.jetbrains.dokka") version "1.4.30" apply false
 }
 
 infra {
@@ -37,4 +38,3 @@ allprojects {
         mavenCentral()
     }
 }
-

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,6 +6,7 @@ import javax.xml.parsers.DocumentBuilderFactory
 plugins {
     id("kotlin-multiplatform")
     `maven-publish`
+    id("org.jetbrains.dokka")
 }
 
 mavenPublicationsPom {
@@ -217,6 +218,17 @@ tasks {
     named("jvmTest", Test::class) {
         // maxHeapSize = "1024m"
 //        executable = "$JDK_6/bin/java"
+    }
+
+    val docsDir = buildDir.resolve("dokka/html")
+
+    dokkaHtml {
+        outputDirectory.set(docsDir)
+    }
+
+    named("javadocJar", org.gradle.jvm.tasks.Jar::class) {
+        dependsOn(dokkaHtml)
+        from(docsDir)
     }
 }
 


### PR DESCRIPTION
Currently blocked by https://github.com/Kotlin/kotlinx.html/issues/81

There are several unresolved classes on the native platform unfortunately, this may happen until Kotlin/Native has a stable API 