### PR TITLE
Implement Instant parsing in common module

### DIFF
--- a/core/common/src/Instant.kt
+++ b/core/common/src/Instant.kt
@@ -123,12 +123,15 @@ public expect class Instant : Comparable<Instant> {
 
         /**
          * Parses a string that represents an instant in ISO-8601 format including date and time components and
-         * the mandatory `Z` designator of the UTC+0 time zone and returns the parsed [Instant] value.
+         * time zone offset.
          *
          * Examples of instants in ISO-8601 format:
+         * - `2020-08-30T18:43Z`
          * - `2020-08-30T18:43:00Z`
          * - `2020-08-30T18:43:00.500Z`
          * - `2020-08-30T18:43:00.123456789Z`
+         * - `2020-08-30T18:43:00+01:00`
+         * - `2020-08-30T18:43:00+0100`
          *
          * @throws IllegalArgumentException if the text cannot be parsed or the boundaries of [Instant] are exceeded.
          */

--- a/core/common/src/InstantParser.kt
+++ b/core/common/src/InstantParser.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019-2021 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.datetime
+
+import kotlin.math.min
+import kotlin.math.pow
+
+internal fun parseInstantCommon(string: String): Instant = parseIsoString(string)
+
+/*
+ * The algorithm for parsing time and zone offset was adapted from
+ * https://github.com/square/moshi/blob/aea17e09bc6a3f9015d3de0e951923f1033d299e/adapters/src/main/java/com/squareup/moshi/adapters/Iso8601Utils.java
+ */
+private fun parseIsoString(isoString: String): Instant {
+    try {
+        val dateTimeSplit = isoString.split('T', ignoreCase = true)
+        if (dateTimeSplit.size != 2) {
+            throw DateTimeFormatException("ISO 8601 datetime must contain exactly one (T|t) delimiter.")
+        }
+        val localDate = LocalDate.parse(dateTimeSplit[0])
+
+        // Iso8601Utils.parse
+        val timePart = dateTimeSplit[1]
+        var offset = 0
+        val hour = parseInt(timePart, offset, offset + 2).also { offset += 2 }
+        if (checkOffset(timePart, offset, ':')) {
+            offset += 1
+        }
+        val minutes = parseInt(timePart, offset, offset + 2).also { offset += 2 }
+        if (checkOffset(timePart, offset, ':')) {
+            offset += 1
+        }
+
+        var seconds = 0
+        var nanosecond = 0
+        // seconds and fraction can be optional
+        if (timePart.length > offset) {
+            val c = timePart[offset]
+            if (c != 'Z' && c != 'z' && c != '+' && c != '-') {
+                seconds = parseInt(timePart, offset, offset + 2).also { offset += 2 }
+                if (seconds > 59 && seconds < 63) { // https://github.com/Kotlin/kotlinx-datetime/issues/5
+                    seconds = 59 // truncate up to 3 leap seconds
+                }
+                if (checkOffset(timePart, offset, '.')) {
+                    offset += 1
+                    val endOffset =
+                        indexOfNonDigit(timePart, offset + 1) // assume at least one digit
+                    val parseEndOffset =
+                        min(endOffset, offset + 9) // parse up to 9 digits
+                    val fraction = parseInt(timePart, offset, parseEndOffset)
+                    nanosecond = (10.0.pow(9 - (parseEndOffset - offset)) * fraction).toInt()
+                    offset = endOffset
+                }
+            }
+        }
+
+        // extract timezone
+        if (timePart.length <= offset) {
+            throw IllegalArgumentException("No time zone indicator in '$timePart'")
+        }
+        val timezone: TimeZone
+        val timezoneIndicator = timePart[offset]
+        if (timezoneIndicator == 'Z' || timezoneIndicator == 'z') {
+            timezone = TimeZone.UTC
+        } else if (timezoneIndicator == '+' || timezoneIndicator == '-') {
+            val timezoneOffset = timePart.substring(offset)
+            // 18-Jun-2015, tatu: Minor simplification, skip offset of "+0000"/"+00:00"
+            if ("+0000" == timezoneOffset || "+00:00" == timezoneOffset) {
+                timezone = TimeZone.UTC
+            } else {
+                val timezoneId = "UTC$timezoneOffset"
+                timezone = TimeZone.of(timezoneId)
+                val act = timezone.id
+                if (act != timezoneId) {
+                    /* 22-Jan-2015, tatu: Looks like canonical version has colons,
+                     * but we may be given one without. If so, don't sweat.
+                     * Yes, very inefficient. Hopefully not hit often.
+                     * If it becomes a perf problem, add 'loose' comparison instead.
+                     */
+                    val cleaned = act.replace(":", "")
+                    if (cleaned != timezoneId) {
+                        throw IllegalTimeZoneException(
+                            "Mismatching time zone indicator: "
+                                    + timezoneId
+                                    + " given, resolves to "
+                                    + timezone.id
+                        )
+                    }
+                }
+            }
+        } else {
+            throw DateTimeFormatException("Invalid time zone indicator '$timezoneIndicator'")
+        }
+        return localDate.atTime(hour, minutes, seconds, nanosecond).toInstant(timezone)
+    } catch (e: NumberFormatException) {
+        throw DateTimeFormatException(e)
+    }
+}
+
+/**
+ * Check if the expected character exist at the given offset in the value.
+ *
+ * @param value the string to check at the specified offset
+ * @param offset the offset to look for the expected character
+ * @param expected the expected character
+ * @return true if the expected character exist at the given offset
+ */
+private fun checkOffset(value: String, offset: Int, expected: Char): Boolean {
+    return (offset < value.length) && (value[offset] == expected)
+}
+
+/**
+ * Parse an integer located between 2 given offsets in a string
+ *
+ * @param value the string to parse
+ * @param beginIndex the start index for the integer in the string
+ * @param endIndex the end index for the integer in the string
+ * @return the int
+ * @throws NumberFormatException if the value is not a number
+ */
+@OptIn(ExperimentalStdlibApi::class)
+private fun parseInt(value: String, beginIndex: Int, endIndex: Int): Int {
+    if ((beginIndex < 0) || (endIndex > value.length) || (beginIndex > endIndex)) {
+        throw NumberFormatException(value)
+    }
+    return value.substring(beginIndex, endIndex).toInt()
+}
+
+/**
+ * Returns the index of the first character in the string that is not a digit, starting at offset.
+ */
+private fun indexOfNonDigit(string: String, offset: Int): Int {
+    for (i in offset until string.length) {
+        val c = string[i]
+        if (c < '0' || c > '9') return i
+    }
+    return string.length
+}

--- a/core/common/src/InstantParser.kt
+++ b/core/common/src/InstantParser.kt
@@ -59,7 +59,7 @@ private fun parseIsoString(isoString: String): Instant {
 
         // extract timezone
         if (timePart.length <= offset) {
-            throw IllegalArgumentException("No time zone indicator in '$timePart'")
+            throw DateTimeFormatException("No time zone indicator in '$timePart'")
         }
         val timezone: TimeZone
         val timezoneIndicator = timePart[offset]

--- a/core/common/test/InstantTest.kt
+++ b/core/common/test/InstantTest.kt
@@ -85,6 +85,7 @@ class InstantTest {
 
         assertInvalidFormat { Instant.parse("x") }
         assertInvalidFormat { Instant.parse("1970-01-01T00:00.1Z") }
+        assertInvalidFormat { Instant.parse("1970-01-01T00:00:00.Z") }
         assertInvalidFormat { Instant.parse("12020-12-31T23:59:59.000000000Z") }
         // this string represents an Instant that is currently larger than Instant.MAX any of the implementations:
         assertInvalidFormat { Instant.parse("+1000000001-12-31T23:59:59.000000000Z") }

--- a/core/common/test/InstantTest.kt
+++ b/core/common/test/InstantTest.kt
@@ -59,9 +59,13 @@ class InstantTest {
     @Test
     fun parseIsoString() {
         val instants = arrayOf(
+            Triple("1970-01-01T0000Z", 0, 0),
+            Triple("1970-01-01T00:00Z", 0, 0),
+            Triple("1970-01-01T000000Z", 0, 0),
             Triple("1970-01-01T00:00:00Z", 0, 0),
             Triple("1970-01-01t00:00:00Z", 0, 0),
             Triple("1970-01-01T00:00:00z", 0, 0),
+            Triple("1970-01-01t00:00:00z", 0, 0),
             Triple("1970-01-01T00:00:00.0Z", 0, 0),
             Triple("1970-01-01T00:00:00.000000000Z", 0, 0),
             Triple("1970-01-01T00:00:00.000000001Z", 0, 1),
@@ -80,9 +84,59 @@ class InstantTest {
         }
 
         assertInvalidFormat { Instant.parse("x") }
+        assertInvalidFormat { Instant.parse("1970-01-01T00:00.1Z") }
         assertInvalidFormat { Instant.parse("12020-12-31T23:59:59.000000000Z") }
         // this string represents an Instant that is currently larger than Instant.MAX any of the implementations:
         assertInvalidFormat { Instant.parse("+1000000001-12-31T23:59:59.000000000Z") }
+    }
+
+    @Test
+    fun isoTimezoneOffsets() {
+        val validOffsets = arrayOf(
+            "1970-01-01T00:00:00Z",
+            "1970-01-01T00:00:00z",
+
+            "1970-01-01T00:00:00+00:00",
+            "1970-01-01T00:00:00+0000",
+
+            "1970-01-01T01:00:00+01:00",
+            "1970-01-01T01:00:00+0100",
+
+            "1970-01-01T18:00:00+18:00",
+            "1970-01-01T18:00:00+1800",
+
+            "1970-01-01T00:01:00+00:01",
+            "1970-01-01T00:01:00+0001",
+
+            "1969-12-31T23:00:00-01:00",
+            "1969-12-31T23:00:00-0100",
+
+            "1969-12-31T06:00:00-18:00",
+            "1969-12-31T06:00:00-1800",
+
+            "1969-12-31T23:59:00-00:01",
+            "1969-12-31T23:59:00-0001",
+        )
+        validOffsets.forEach {
+            assertEquals(0, Instant.parse(it).toEpochMilliseconds())
+        }
+
+        val invalidOffsets = arrayOf(
+            "1970-01-01T18:01:00+18:01",
+            "1970-01-01T18:01:00+1801",
+
+            "1969-12-31T05:59:00-18:01",
+            "1969-12-31T05:59:00-1801",
+
+            "1970-01-01T01:00:00+01",
+            "1970-01-01T01:00:00+01",
+
+            "1970-01-01T01:00:00+1:00",
+            "1970-01-01T01:00:00+100",
+        )
+        invalidOffsets.forEach {
+            assertFailsWith<IllegalArgumentException> { Instant.parse(it) }
+        }
     }
 
     @OptIn(ExperimentalTime::class)

--- a/core/js/src/Instant.kt
+++ b/core/js/src/Instant.kt
@@ -75,12 +75,7 @@ public actual class Instant internal constructor(internal val value: jtInstant) 
             if (epochMilliseconds > 0) MAX else MIN
         }
 
-        actual fun parse(isoString: String): Instant = try {
-            Instant(jtInstant.parse(isoString))
-        } catch (e: Throwable) {
-            if (e.isJodaDateTimeParseException()) throw DateTimeFormatException(e)
-            throw e
-        }
+        actual fun parse(isoString: String): Instant = parseInstantCommon(isoString)
 
         actual fun fromEpochSeconds(epochSeconds: Long, nanosecondAdjustment: Long): Instant = try {
             /* Performing normalization here because otherwise this fails:

--- a/core/jvm/src/Instant.kt
+++ b/core/jvm/src/Instant.kt
@@ -9,7 +9,6 @@ package kotlinx.datetime
 import kotlinx.datetime.serializers.InstantIso8601Serializer
 import kotlinx.serialization.Serializable
 import java.time.DateTimeException
-import java.time.format.DateTimeParseException
 import java.time.temporal.ChronoUnit
 import kotlin.time.*
 import java.time.Instant as jtInstant
@@ -62,11 +61,7 @@ public actual class Instant internal constructor(internal val value: jtInstant) 
         actual fun fromEpochMilliseconds(epochMilliseconds: Long): Instant =
                 Instant(jtInstant.ofEpochMilli(epochMilliseconds))
 
-        actual fun parse(isoString: String): Instant = try {
-            Instant(jtInstant.parse(isoString))
-        } catch (e: DateTimeParseException) {
-            throw DateTimeFormatException(e)
-        }
+        actual fun parse(isoString: String): Instant = parseInstantCommon(isoString)
 
         actual fun fromEpochSeconds(epochSeconds: Long, nanosecondAdjustment: Long): Instant = try {
             Instant(jtInstant.ofEpochSecond(epochSeconds, nanosecondAdjustment))


### PR DESCRIPTION
Resolves #56 

Instant.parse now supports:
- Time zone offsets in the form of `+-hh:mm` and `+-hhmm`
- Time part allows the omission of colons (allows hhmmss)
- Time part allows the omission of seconds

Implementation notes:
Input string is split by the time delimiter (T|t) into date and time parts.
Date parsing is delegated to `LocalDate.parse`
Time parsing employs the well known algorithm from `Iso8601Utils.java`
originally implemented in Jackson. This commit is based on Moshi's
version of that file.

##### Motivation
Any datetime library worth its salt *must* be able to parse numeric time zone offsets. I'm afraid here's no way around it.
I initially implemented this for myself since I need the ability to parse numeric time zone offsets. In fact I think that most of the `OffsetDateTime`-type strings floating around the Internet come with the `+-hh:mm` offset representation rather than the `Z` designator. Migrating from `ThreeTenBP` I was surprised that only the `Z` designator was supported.

This implementation may hold fort until a format builder is added (#58 #39)

###### Discussion points:
The leniency of the time parser comes free with the algorithm.
1. Should the omission of colons in time be allowed?
2. Should the omission of seconds be allowed?

I vote that the leniency be kept in the spirit of the "Be permissive on input, strict on output" rule of thumb.