### PR TITLE
Enable support for watchosX64

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
             target("watchosArm32")
             target("watchosArm64")
             target("watchosX86")
+            target("watchosX64")
             target("tvosArm64")
             target("tvosX64")
         }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -152,7 +152,7 @@ kotlin {
         commonMain {
             dependencies {
                 api("org.jetbrains.kotlin:kotlin-stdlib-common")
-                compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
             }
         }
 
@@ -192,7 +192,6 @@ kotlin {
         val jsMain by getting {
             dependencies {
                 api("org.jetbrains.kotlin:kotlin-stdlib-js")
-                api("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
                 implementation(npm("@js-joda/core",  "3.2.0"))
             }
         }
@@ -206,9 +205,6 @@ kotlin {
 
         val nativeMain by getting {
             dependsOn(commonMain.get())
-            dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
-            }
         }
 
         val nativeTest by getting {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ group=org.jetbrains.kotlinx
 version=0.2.0
 versionSuffix=SNAPSHOT
 
-serializationVersion=1.1.0
+serializationVersion=1.2.1
 
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.enableCompatibilityMetadataVariant=true

--- a/serialization/build.gradle.kts
+++ b/serialization/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
         target("watchosArm32")
         target("watchosArm64")
         target("watchosX86")
+        target("watchosX64")
         target("tvosArm64")
         target("tvosX64")
     }


### PR DESCRIPTION
Supersedes #93, with the changes:
- Enables `watchosX64` in both modules, not just core.
- Rebased from `master`, fixing inconsistencies with the stdlib (1.4.30 and 1.5.0 are source-incompatible, hence the CI failure in #93).
- The above enables switching to kotlinx.serialization 1.2.1 (watchosX64 is only supported on 1.2.0 and up).
- Simplified setup, with kotlinx.serialization being declared only once.
- Test suite should be green, but I can't trigger TeamCity. 😄 