### PR TITLE
Upgrade Kotlin to 1.5.31 and add support for macosArm64

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,15 +30,19 @@ kotlin {
 
         common("darwin") {
             target("macosX64")
+            target("macosArm64")
             target("iosX64")
             target("iosArm64")
             target("iosArm32")
+            target("iosSimulatorArm64")
             target("watchosArm32")
             target("watchosArm64")
             target("watchosX86")
             target("watchosX64")
+            target("watchosSimulatorArm64")
             target("tvosArm64")
             target("tvosX64")
+            target("tvosSimulatorArm64")
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ version=0.2.1
 versionSuffix=SNAPSHOT
 
 kotlinVersion=1.5.30
-serializationVersion=1.3.0-RC
+serializationVersion=1.3.0
 
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.enableCompatibilityMetadataVariant=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ group=org.jetbrains.kotlinx
 version=0.2.1
 versionSuffix=SNAPSHOT
 
-kotlinVersion=1.5.0
-serializationVersion=1.2.1
+kotlinVersion=1.5.30
+serializationVersion=1.3.0-RC
 
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.enableCompatibilityMetadataVariant=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ group=org.jetbrains.kotlinx
 version=0.2.1
 versionSuffix=SNAPSHOT
 
-kotlinVersion=1.5.30
+kotlinVersion=1.5.31
 serializationVersion=1.3.0
 
 kotlin.mpp.enableGranularSourceSetsMetadata=true

--- a/serialization/build.gradle.kts
+++ b/serialization/build.gradle.kts
@@ -13,15 +13,19 @@ kotlin {
         target("linuxX64")
         target("mingwX64")
         target("macosX64")
+        target("macosArm64")
         target("iosX64")
         target("iosArm64")
         target("iosArm32")
+        target("iosSimulatorArm64")
         target("watchosArm32")
         target("watchosArm64")
         target("watchosX86")
         target("watchosX64")
+        target("watchosSimulatorArm64")
         target("tvosArm64")
         target("tvosX64")
+        target("tvosSimulatorArm64")
     }
 
     jvm {


### PR DESCRIPTION
Also iosSimulatorArm64, watchosSimulatorArm64, and tvosSimulatorArm64.

Closes: https://github.com/Kotlin/kotlinx-datetime/issues/141