### PR TITLE
Bump Kotlin to 1.6.0 and remove ExperimentalTime

### DIFF
--- a/core/common/src/Clock.kt
+++ b/core/common/src/Clock.kt
@@ -5,10 +5,7 @@
 
 package kotlinx.datetime
 
-import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
-import kotlin.time.TimeMark
-import kotlin.time.TimeSource
+import kotlin.time.*
 
 public interface Clock {
     public fun now(): Instant
@@ -24,7 +21,6 @@ public interface Clock {
 
 public fun Clock.todayAt(timeZone: TimeZone): LocalDate =
         now().toLocalDateTime(timeZone).date
-
 
 @ExperimentalTime
 public fun Clock.asTimeSource(): TimeSource = object : TimeSource {

--- a/core/common/src/DateTimePeriod.kt
+++ b/core/common/src/DateTimePeriod.kt
@@ -9,7 +9,6 @@ import kotlinx.datetime.serializers.DatePeriodIso8601Serializer
 import kotlinx.datetime.serializers.DateTimePeriodIso8601Serializer
 import kotlin.math.*
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 import kotlinx.serialization.Serializable
 
 @Serializable(with = DateTimePeriodIso8601Serializer::class)
@@ -307,7 +306,6 @@ public fun DateTimePeriod(
 ): DateTimePeriod = buildDateTimePeriod(totalMonths(years, months), days,
     totalNanoseconds(hours, minutes, seconds, nanoseconds))
 
-@OptIn(ExperimentalTime::class)
 public fun Duration.toDateTimePeriod(): DateTimePeriod = buildDateTimePeriod(totalNanoseconds = inWholeNanoseconds)
 
 public operator fun DateTimePeriod.plus(other: DateTimePeriod): DateTimePeriod = buildDateTimePeriod(
@@ -320,4 +318,3 @@ public operator fun DatePeriod.plus(other: DatePeriod): DatePeriod = DatePeriod(
     safeAdd(totalMonths, other.totalMonths),
     safeAdd(days, other.days),
 )
-

--- a/core/common/src/DateTimeUnit.kt
+++ b/core/common/src/DateTimeUnit.kt
@@ -8,6 +8,7 @@ package kotlinx.datetime
 import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 import kotlin.time.*
+import kotlin.time.Duration.Companion.nanoseconds
 
 @Serializable(with = DateTimeUnitSerializer::class)
 public sealed class DateTimeUnit {
@@ -52,9 +53,8 @@ public sealed class DateTimeUnit {
 
         override fun times(scalar: Int): TimeBased = TimeBased(safeMultiply(nanoseconds, scalar.toLong()))
 
-        @ExperimentalTime
         public val duration: Duration
-            get() = Duration.nanoseconds(nanoseconds)
+            get() = nanoseconds.nanoseconds
 
         override fun equals(other: Any?): Boolean =
                 this === other || (other is TimeBased && this.nanoseconds == other.nanoseconds)

--- a/core/common/src/Instant.kt
+++ b/core/common/src/Instant.kt
@@ -9,7 +9,6 @@ import kotlinx.datetime.serializers.InstantIso8601Serializer
 import kotlinx.serialization.Serializable
 import kotlin.time.*
 
-@OptIn(ExperimentalTime::class)
 @Serializable(with = InstantIso8601Serializer::class)
 public expect class Instant : Comparable<Instant> {
 
@@ -51,7 +50,6 @@ public expect class Instant : Comparable<Instant> {
      *
      * The return value is clamped to the platform-specific boundaries for [Instant] if the result exceeds them.
      */
-    @ExperimentalTime
     public operator fun plus(duration: Duration): Instant
 
     /**
@@ -62,7 +60,6 @@ public expect class Instant : Comparable<Instant> {
      *
      * The return value is clamped to the platform-specific boundaries for [Instant] if the result exceeds them.
      */
-    @ExperimentalTime
     public operator fun minus(duration: Duration): Instant
 
     // questionable
@@ -75,7 +72,6 @@ public expect class Instant : Comparable<Instant> {
      * The result is never clamped, but note that for instants that are far apart,
      * the value returned may represent the duration between them inexactly due to the loss of precision.
      */
-    @ExperimentalTime
     public operator fun minus(other: Instant): Duration
 
     /**

--- a/core/common/src/serializers/DateTimeUnitSerializers.kt
+++ b/core/common/src/serializers/DateTimeUnitSerializers.kt
@@ -26,7 +26,7 @@ public object TimeBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.TimeBase
         }
     }
 
-    @ExperimentalSerializationApi
+    @OptIn(ExperimentalSerializationApi::class)
     @Suppress("INVISIBLE_MEMBER") // to be able to throw `MissingFieldException`
     override fun deserialize(decoder: Decoder): DateTimeUnit.TimeBased {
         var seen = false
@@ -65,7 +65,7 @@ public object DayBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.DayBased>
         }
     }
 
-    @ExperimentalSerializationApi
+    @OptIn(ExperimentalSerializationApi::class)
     @Suppress("INVISIBLE_MEMBER") // to be able to throw `MissingFieldException`
     override fun deserialize(decoder: Decoder): DateTimeUnit.DayBased {
         var seen = false
@@ -104,7 +104,7 @@ public object MonthBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.MonthBa
         }
     }
 
-    @ExperimentalSerializationApi
+    @OptIn(ExperimentalSerializationApi::class)
     @Suppress("INVISIBLE_MEMBER") // to be able to throw `MissingFieldException`
     override fun deserialize(decoder: Decoder): DateTimeUnit.MonthBased {
         var seen = false
@@ -149,11 +149,13 @@ public object DateBasedDateTimeUnitSerializer: AbstractPolymorphicSerializer<Dat
             SerializationStrategy<DateTimeUnit.DateBased>? =
         impl.findPolymorphicSerializerOrNull(encoder, value)
 
-    @InternalSerializationApi
+
+    @OptIn(InternalSerializationApi::class)
     override val baseClass: KClass<DateTimeUnit.DateBased>
         get() = DateTimeUnit.DateBased::class
 
-    @InternalSerializationApi
+
+    @OptIn(InternalSerializationApi::class)
     override val descriptor: SerialDescriptor
         get() = impl.descriptor
 
@@ -175,11 +177,13 @@ public object DateTimeUnitSerializer: AbstractPolymorphicSerializer<DateTimeUnit
     override fun findPolymorphicSerializerOrNull(encoder: Encoder, value: DateTimeUnit): SerializationStrategy<DateTimeUnit>? =
         impl.findPolymorphicSerializerOrNull(encoder, value)
 
-    @InternalSerializationApi
+
+    @OptIn(InternalSerializationApi::class)
     override val baseClass: KClass<DateTimeUnit>
         get() = DateTimeUnit::class
 
-    @InternalSerializationApi
+
+    @OptIn(InternalSerializationApi::class)
     override val descriptor: SerialDescriptor
         get() = impl.descriptor
 

--- a/core/common/test/DateTimePeriodTest.kt
+++ b/core/common/test/DateTimePeriodTest.kt
@@ -5,10 +5,13 @@
 
 package kotlinx.datetime.test
 
-import kotlin.test.*
 import kotlinx.datetime.*
+import kotlin.test.*
 import kotlin.time.*
-
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class DateTimePeriodTest {
 
@@ -151,7 +154,6 @@ class DateTimePeriodTest {
         assertTrue(dp2 is DatePeriod)
     }
 
-    @OptIn(ExperimentalTime::class)
     @Test
     fun durationConversion() {
         val periodZero = Duration.ZERO.toDateTimePeriod()
@@ -160,10 +162,10 @@ class DateTimePeriodTest {
         assertTrue(periodZero is DatePeriod)
 
         for ((period, duration) in listOf(
-                DateTimePeriod(hours = 1) to Duration.hours(1),
-                DateTimePeriod(hours = 2) to Duration.minutes(120),
-                DateTimePeriod(minutes = 2, seconds = 30) to Duration.seconds(150),
-                DateTimePeriod(seconds = 2) to Duration.nanoseconds(2e9)
+            DateTimePeriod(hours = 1) to 1.hours,
+            DateTimePeriod(hours = 2) to 120.minutes,
+            DateTimePeriod(minutes = 2, seconds = 30) to 150.seconds,
+            DateTimePeriod(seconds = 2) to 2e9.nanoseconds
         )) {
             assertEquals(period, duration.toDateTimePeriod())
         }

--- a/core/common/test/InstantTest.kt
+++ b/core/common/test/InstantTest.kt
@@ -4,11 +4,16 @@
  */
 
 package kotlinx.datetime.test
+
 import kotlinx.datetime.*
 import kotlinx.datetime.Clock // currently, requires an explicit import due to a conflict with the deprecated Clock from kotlin.time
 import kotlin.random.*
 import kotlin.test.*
 import kotlin.time.*
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
 
 class InstantTest {
 
@@ -30,12 +35,11 @@ class InstantTest {
         assertNotEquals(notEqualInstant, instant)
     }
 
-    @OptIn(ExperimentalTime::class)
     @Test
     fun instantArithmetic() {
         val instant = Clock.System.now().toEpochMilliseconds().let { Instant.fromEpochMilliseconds(it) } // round to millis
         val diffMillis = Random.nextLong(1000, 1_000_000_000)
-        val diff = Duration.milliseconds(diffMillis)
+        val diff = diffMillis.milliseconds
 
         val nextInstant = (instant.toEpochMilliseconds() + diffMillis).let { Instant.fromEpochMilliseconds(it) }
 
@@ -129,7 +133,6 @@ class InstantTest {
         }
     }
 
-    @OptIn(ExperimentalTime::class)
     @Test
     fun instantCalendarArithmetic() {
         val zone = TimeZone.of("Europe/Berlin")
@@ -180,7 +183,7 @@ class InstantTest {
         checkComponents(instant5.toLocalDateTime(zone), 2019, 10, 28, 3, 59)
         assertEquals(period, instant1.periodUntil(instant5, zone))
         assertEquals(period, instant5.minus(instant1, zone))
-        assertEquals(Duration.hours(26), instant5.minus(instant1))
+        assertEquals(26.hours, instant5.minus(instant1))
         assertEquals(instant1.plus(DateTimeUnit.HOUR), instant5.minus(period, zone))
 
         val instant6 = instant1.plus(23, DateTimeUnit.HOUR, zone)
@@ -202,7 +205,6 @@ class InstantTest {
         assertEquals(pow2_32, instant3.epochSeconds)
     }
 
-    @OptIn(ExperimentalTime::class)
     @Test
     fun unitMultiplesUntil() {
         val unit1000days = DateTimeUnit.DAY * 1000
@@ -227,7 +229,6 @@ class InstantTest {
         assertEquals(start, end.plus(-diffUs, DateTimeUnit.MICROSECOND, zone))
     }
 
-    @OptIn(ExperimentalTime::class)
     @Test
     fun instantOffset() {
         val zone = TimeZone.of("Europe/Berlin")
@@ -237,15 +238,15 @@ class InstantTest {
         checkComponents(ldt1, 2019, 10, 27, 2, 59)
         assertEquals(instant1, ldt1.toInstant(offset1))
 
-        val instant2 = instant1 + Duration.hours(1)
+        val instant2 = instant1 + 1.hours
         val ldt2 = instant2.toLocalDateTime(zone)
         val offset2 = instant2.offsetIn(zone)
         assertEquals(ldt1, ldt2)
         assertEquals(instant2, ldt2.toInstant(offset2))
         assertNotEquals(offset1, offset2)
-        assertEquals(Duration.seconds(offset1.totalSeconds), Duration.seconds(offset2.totalSeconds) + Duration.hours(1))
+        assertEquals(offset1.totalSeconds.seconds, offset2.totalSeconds.seconds + 1.hours)
 
-        val instant3 = instant2 - Duration.hours(2)
+        val instant3 = instant2 - 2.hours
         val offset3 = instant3.offsetIn(zone)
         assertEquals(offset1, offset3)
     }
@@ -348,7 +349,6 @@ class InstantTest {
     /* Based on the ThreeTenBp project.
      * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
      */
-//    @ExperimentalTime
     @Test
     fun strings() {
         assertEquals("0000-01-02T00:00:00Z", LocalDateTime(0, 1, 2, 0, 0, 0, 0).toInstant(TimeZone.UTC).toString())
@@ -401,7 +401,6 @@ class InstantTest {
         assertEquals("+19999-12-31T23:59:59.000000009Z", LocalDateTime(19999, 12, 31, 23, 59, 59, 9).toInstant(TimeZone.UTC).toString())
     }
 
-    @ExperimentalTime
     @Test
     fun distantPastAndFuture() {
         val distantFutureString = "+100000-01-01T00:00:00Z"
@@ -414,10 +413,10 @@ class InstantTest {
         assertTrue(Instant.DISTANT_FUTURE.isDistantFuture)
         assertFalse(Instant.DISTANT_PAST.isDistantFuture)
         assertFalse(Instant.DISTANT_FUTURE.isDistantPast)
-        assertFalse((Instant.DISTANT_PAST + Duration.nanoseconds(1)).isDistantPast)
-        assertFalse((Instant.DISTANT_FUTURE - Duration.nanoseconds(1)).isDistantFuture)
-        assertTrue((Instant.DISTANT_PAST - Duration.nanoseconds(1)).isDistantPast)
-        assertTrue((Instant.DISTANT_FUTURE + Duration.nanoseconds(1)).isDistantFuture)
+        assertFalse((Instant.DISTANT_PAST + 1.nanoseconds).isDistantPast)
+        assertFalse((Instant.DISTANT_FUTURE - 1.nanoseconds).isDistantFuture)
+        assertTrue((Instant.DISTANT_PAST - 1.nanoseconds).isDistantPast)
+        assertTrue((Instant.DISTANT_FUTURE + 1.nanoseconds).isDistantFuture)
         assertTrue(Instant.MAX.isDistantFuture)
         assertFalse(Instant.MAX.isDistantPast)
         assertTrue(Instant.MIN.isDistantPast)
@@ -426,7 +425,6 @@ class InstantTest {
 
 }
 
-@OptIn(ExperimentalTime::class)
 class InstantRangeTest {
     private val UTC = TimeZone.UTC
     private val maxValidInstant = LocalDateTime.MAX.toInstant(UTC)
@@ -435,8 +433,8 @@ class InstantRangeTest {
     private val largePositiveLongs = listOf(Long.MAX_VALUE, Long.MAX_VALUE - 1, Long.MAX_VALUE - 50)
     private val largeNegativeLongs = listOf(Long.MIN_VALUE, Long.MIN_VALUE + 1, Long.MIN_VALUE + 50)
 
-    private val largePositiveInstants = listOf(Instant.MAX, Instant.MAX - Duration.seconds(1), Instant.MAX - Duration.seconds(50))
-    private val largeNegativeInstants = listOf(Instant.MIN, Instant.MIN + Duration.seconds(1), Instant.MIN + Duration.seconds(50))
+    private val largePositiveInstants = listOf(Instant.MAX, Instant.MAX - 1.seconds, Instant.MAX - 50.seconds)
+    private val largeNegativeInstants = listOf(Instant.MIN, Instant.MIN + 1.seconds, Instant.MIN + 50.seconds)
 
     private val smallInstants = listOf(
         Instant.fromEpochMilliseconds(0),
@@ -504,8 +502,8 @@ class InstantRangeTest {
                 assertEquals(Instant.MIN, instant - duration)
             }
         }
-        assertEquals(Instant.MAX, (Instant.MAX - Duration.seconds(4)) + Duration.seconds(5))
-        assertEquals(Instant.MIN, (Instant.MIN + Duration.seconds(10)) - Duration.seconds(12))
+        assertEquals(Instant.MAX, (Instant.MAX - 4.seconds) + 5.seconds)
+        assertEquals(Instant.MIN, (Instant.MIN + 10.seconds) - 12.seconds)
     }
 
     @Test
@@ -534,8 +532,8 @@ class InstantRangeTest {
         // Overflowing a LocalDateTime in input
         maxValidInstant.plus(DateTimePeriod(nanoseconds = -1), UTC)
         minValidInstant.plus(DateTimePeriod(nanoseconds = 1), UTC)
-        assertArithmeticFails { (maxValidInstant + Duration.nanoseconds(1)).plus(DateTimePeriod(nanoseconds = -2), UTC) }
-        assertArithmeticFails { (minValidInstant - Duration.nanoseconds(1)).plus(DateTimePeriod(nanoseconds = 2), UTC) }
+        assertArithmeticFails { (maxValidInstant + 1.nanoseconds).plus(DateTimePeriod(nanoseconds = -2), UTC) }
+        assertArithmeticFails { (minValidInstant - 1.nanoseconds).plus(DateTimePeriod(nanoseconds = 2), UTC) }
         // Overflowing a LocalDateTime in result
         assertArithmeticFails { maxValidInstant.plus(DateTimePeriod(nanoseconds = 1), UTC) }
         assertArithmeticFails { minValidInstant.plus(DateTimePeriod(nanoseconds = -1), UTC) }
@@ -557,8 +555,8 @@ class InstantRangeTest {
         // Overflowing a LocalDateTime in input
         maxValidInstant.plus(-1, DateTimeUnit.NANOSECOND, UTC)
         minValidInstant.plus(1, DateTimeUnit.NANOSECOND, UTC)
-        assertArithmeticFails { (maxValidInstant + Duration.nanoseconds(1)).plus(-2, DateTimeUnit.NANOSECOND, UTC) }
-        assertArithmeticFails { (minValidInstant - Duration.nanoseconds(1)).plus(2, DateTimeUnit.NANOSECOND, UTC) }
+        assertArithmeticFails { (maxValidInstant + 1.nanoseconds).plus(-2, DateTimeUnit.NANOSECOND, UTC) }
+        assertArithmeticFails { (minValidInstant - 1.nanoseconds).plus(2, DateTimeUnit.NANOSECOND, UTC) }
         // Overflowing a LocalDateTime in result
         assertArithmeticFails { maxValidInstant.plus(1, DateTimeUnit.NANOSECOND, UTC) }
         assertArithmeticFails { maxValidInstant.plus(1, DateTimeUnit.YEAR, UTC) }
@@ -586,8 +584,8 @@ class InstantRangeTest {
     fun periodUntilOutOfRange() {
         // Instant.periodUntil
         maxValidInstant.periodUntil(maxValidInstant, UTC)
-        assertArithmeticFails { (maxValidInstant + Duration.nanoseconds(1)).periodUntil(maxValidInstant, UTC) }
-        assertArithmeticFails { minValidInstant.periodUntil(minValidInstant - Duration.nanoseconds(1), UTC) }
+        assertArithmeticFails { (maxValidInstant + 1.nanoseconds).periodUntil(maxValidInstant, UTC) }
+        assertArithmeticFails { minValidInstant.periodUntil(minValidInstant - 1.nanoseconds, UTC) }
     }
 
     @Test
@@ -603,11 +601,10 @@ class InstantRangeTest {
     fun unitsUntilOutOfRange() {
         // Instant.until
         // Overflowing a LocalDateTime in input
-        assertArithmeticFails { (maxValidInstant + Duration.nanoseconds(1)).until(maxValidInstant, DateTimeUnit.NANOSECOND, UTC) }
-        assertArithmeticFails { maxValidInstant.until(maxValidInstant + Duration.nanoseconds(1), DateTimeUnit.NANOSECOND, UTC) }
+        assertArithmeticFails { (maxValidInstant + 1.nanoseconds).until(maxValidInstant, DateTimeUnit.NANOSECOND, UTC) }
+        assertArithmeticFails { maxValidInstant.until(maxValidInstant + 1.nanoseconds, DateTimeUnit.NANOSECOND, UTC) }
         // Overloads without a TimeZone should not fail on overflowing a LocalDateTime
-        (maxValidInstant + Duration.nanoseconds(1)).until(maxValidInstant, DateTimeUnit.NANOSECOND)
-        maxValidInstant.until(maxValidInstant + Duration.nanoseconds(1), DateTimeUnit.NANOSECOND)
+        (maxValidInstant + 1.nanoseconds).until(maxValidInstant, DateTimeUnit.NANOSECOND)
+        maxValidInstant.until(maxValidInstant + 1.nanoseconds, DateTimeUnit.NANOSECOND)
     }
 }
-

--- a/core/common/test/LocalDateTimeTest.kt
+++ b/core/common/test/LocalDateTimeTest.kt
@@ -9,6 +9,12 @@ import kotlinx.datetime.*
 import kotlinx.datetime.Clock
 import kotlin.test.*
 import kotlin.time.*
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.microseconds
 
 class LocalDateTimeTest {
 
@@ -36,25 +42,23 @@ class LocalDateTimeTest {
         checkParsedComponents("-2008-01-02T23:59:59.999999990", -2008, 1, 2, 23, 59, 59, 999999990)
     }
 
-    @OptIn(ExperimentalTime::class)
     @Test
     fun localDtToInstantConversion() {
         val ldt1 = "2019-10-01T18:43:15.100500".toLocalDateTime()
         val ldt2 = "2019-10-01T19:50:00.500600".toLocalDateTime()
 
         val diff = with(TimeZone.UTC) { ldt2.toInstant() - ldt1.toInstant() }
-        assertEquals(with(Duration) { hours(1) + minutes(7) - seconds(15) + microseconds(400100) }, diff)
-        assertFailsWith<DateTimeArithmeticException> { (Instant.MAX - Duration.days(3)).toLocalDateTime(TimeZone.UTC) }
-        assertFailsWith<DateTimeArithmeticException> { (Instant.MIN + Duration.hours(6)).toLocalDateTime(TimeZone.UTC) }
+        assertEquals(with(Duration) { 1.hours + 7.minutes - 15.seconds + 400100.microseconds }, diff)
+        assertFailsWith<DateTimeArithmeticException> { (Instant.MAX - 3.days).toLocalDateTime(TimeZone.UTC) }
+        assertFailsWith<DateTimeArithmeticException> { (Instant.MIN + 6.hours).toLocalDateTime(TimeZone.UTC) }
     }
 
-    @OptIn(ExperimentalTime::class)
     @Test
     fun localDtToInstantConversionRespectsTimezones() {
         val ldt1 = "2011-03-26T04:00:00".toLocalDateTime()
         val ldt2 = "2011-03-27T04:00:00".toLocalDateTime()
         val diff = with(TimeZone.of("Europe/Moscow")) { ldt2.toInstant() - ldt1.toInstant() }
-        assertEquals(Duration.hours(23), diff)
+        assertEquals(23.hours, diff)
     }
 
     @Test
@@ -72,7 +76,6 @@ class LocalDateTimeTest {
         }
     }
 
-    @OptIn(ExperimentalTime::class)
     @Test
     fun tomorrow() {
         val localFixed = LocalDateTime(2019, 1, 30, 0, 0, 0, 0)
@@ -140,4 +143,3 @@ fun checkEquals(expected: LocalDateTime, actual: LocalDateTime) {
     assertEquals(expected.hashCode(), actual.hashCode())
     assertEquals(expected.toString(), actual.toString())
 }
-

--- a/core/common/test/LocalDateTimeTest.kt
+++ b/core/common/test/LocalDateTimeTest.kt
@@ -10,11 +10,7 @@ import kotlinx.datetime.Clock
 import kotlin.test.*
 import kotlin.time.*
 import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.nanoseconds
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Duration.Companion.days
-import kotlin.time.Duration.Companion.microseconds
 
 class LocalDateTimeTest {
 

--- a/core/js/src/Instant.kt
+++ b/core/js/src/Instant.kt
@@ -14,9 +14,10 @@ import kotlinx.datetime.internal.JSJoda.ChronoUnit
 import kotlinx.datetime.serializers.InstantIso8601Serializer
 import kotlinx.serialization.Serializable
 import kotlin.time.*
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
 
 @Serializable(with = InstantIso8601Serializer::class)
-@OptIn(ExperimentalTime::class)
 public actual class Instant internal constructor(internal val value: jtInstant) : Comparable<Instant> {
 
     public actual val epochSeconds: Long
@@ -46,7 +47,7 @@ public actual class Instant internal constructor(internal val value: jtInstant) 
 
     public actual operator fun minus(other: Instant): Duration {
         val diff = jtDuration.between(other.value, this.value)
-        return Duration.seconds(diff.seconds().toDouble()) + Duration.nanoseconds(diff.nano().toDouble())
+        return diff.seconds().toDouble().seconds + diff.nano().toDouble().nanoseconds
     }
 
     public actual override operator fun compareTo(other: Instant): Int = this.value.compareTo(other.value).toInt()
@@ -189,7 +190,6 @@ public actual fun Instant.plus(value: Long, unit: DateTimeUnit.TimeBased): Insta
         if (value > 0) Instant.MAX else Instant.MIN
     }
 
-@OptIn(ExperimentalTime::class)
 public actual fun Instant.periodUntil(other: Instant, timeZone: TimeZone): DateTimePeriod = try {
     var thisZdt = this.value.atZone(timeZone.zoneId)
     val otherZdt = other.value.atZone(timeZone.zoneId)

--- a/core/jvm/src/Instant.kt
+++ b/core/jvm/src/Instant.kt
@@ -12,12 +12,13 @@ import java.time.DateTimeException
 import java.time.format.DateTimeParseException
 import java.time.temporal.ChronoUnit
 import kotlin.time.*
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
 import java.time.Instant as jtInstant
 import java.time.OffsetDateTime as jtOffsetDateTime
 import java.time.Clock as jtClock
 
 @Serializable(with = InstantIso8601Serializer::class)
-@OptIn(ExperimentalTime::class)
 public actual class Instant internal constructor(internal val value: jtInstant) : Comparable<Instant> {
 
     public actual val epochSeconds: Long
@@ -43,8 +44,8 @@ public actual class Instant internal constructor(internal val value: jtInstant) 
     public actual operator fun minus(duration: Duration): Instant = plus(-duration)
 
     public actual operator fun minus(other: Instant): Duration =
-            Duration.seconds(this.value.epochSecond - other.value.epochSecond) + // won't overflow given the instant bounds
-            Duration.nanoseconds(this.value.nano - other.value.nano)
+        (this.value.epochSecond - other.value.epochSecond).seconds + // won't overflow given the instant bounds
+            (this.value.nano - other.value.nano).nanoseconds
 
     public actual override operator fun compareTo(other: Instant): Int = this.value.compareTo(other.value)
 
@@ -153,7 +154,6 @@ public actual fun Instant.plus(value: Long, unit: DateTimeUnit.TimeBased): Insta
         if (value > 0) Instant.MAX else Instant.MIN
     }
 
-@OptIn(ExperimentalTime::class)
 public actual fun Instant.periodUntil(other: Instant, timeZone: TimeZone): DateTimePeriod {
     var thisZdt = this.atZone(timeZone)
     val otherZdt = other.atZone(timeZone)

--- a/core/native/cinterop/cpp/windows.cpp
+++ b/core/native/cinterop/cpp/windows.cpp
@@ -11,8 +11,8 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 
-#include <Windows.h>
-#include <Timezoneapi.h>
+#include <windows.h>
+#include <timezoneapi.h>
 #include <stdexcept>
 #include <string>
 #include <cstring>

--- a/core/native/src/Instant.kt
+++ b/core/native/src/Instant.kt
@@ -12,6 +12,8 @@ import kotlinx.datetime.serializers.InstantIso8601Serializer
 import kotlinx.serialization.Serializable
 import kotlin.math.*
 import kotlin.time.*
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
 
 public actual enum class DayOfWeek {
     MONDAY,
@@ -127,7 +129,6 @@ private fun isValidInstantSecond(second: Long) = second >= MIN_SECOND && second 
 internal expect fun currentTime(): Instant
 
 @Serializable(with = InstantIso8601Serializer::class)
-@OptIn(ExperimentalTime::class)
 public actual class Instant internal constructor(public actual val epochSeconds: Long, public actual val nanosecondsOfSecond: Int) : Comparable<Instant> {
 
     init {
@@ -166,8 +167,8 @@ public actual class Instant internal constructor(public actual val epochSeconds:
     public actual operator fun minus(duration: Duration): Instant = plus(-duration)
 
     public actual operator fun minus(other: Instant): Duration =
-        Duration.seconds(this.epochSeconds - other.epochSeconds) + // won't overflow given the instant bounds
-        Duration.nanoseconds(this.nanosecondsOfSecond - other.nanosecondsOfSecond)
+        (this.epochSeconds - other.epochSeconds).seconds + // won't overflow given the instant bounds
+        (this.nanosecondsOfSecond - other.nanosecondsOfSecond).nanoseconds
 
     actual override fun compareTo(other: Instant): Int {
         val s = epochSeconds.compareTo(other.epochSeconds)
@@ -302,7 +303,6 @@ public actual fun Instant.plus(value: Long, unit: DateTimeUnit.TimeBased): Insta
         if (value > 0) Instant.MAX else Instant.MIN
     }
 
-@OptIn(ExperimentalTime::class)
 public actual fun Instant.periodUntil(other: Instant, timeZone: TimeZone): DateTimePeriod {
     var thisLdt = toZonedDateTimeFailing(timeZone)
     val otherLdt = other.toZonedDateTimeFailing(timeZone)

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,8 @@ group=org.jetbrains.kotlinx
 version=0.3.1
 versionSuffix=SNAPSHOT
 
-kotlinVersion=1.5.30
-serializationVersion=1.3.0
+kotlinVersion=1.6.0
+serializationVersion=1.3.1
 
 java.mainToolchainVersion=8
 java.modularToolchainVersion=11


### PR DESCRIPTION
Fixes #156
Supersedes https://github.com/Kotlin/kotlinx-datetime/pull/159