### PR TITLE
Ignore local.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@
 target
 build
 /local.properties
-/kotlinx-collections-immutable/dependency-reduced-pom.xml
-/benchmarks-runner/benchmarkResults
-/benchmarks-runner/localReferenceBenchmarkResults

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.iml
 target
 build
+/local.properties
 /kotlinx-collections-immutable/dependency-reduced-pom.xml
 /benchmarks-runner/benchmarkResults
 /benchmarks-runner/localReferenceBenchmarkResults


### PR DESCRIPTION
That file is auto-created by Android Studio and should never be committed.