### PR TITLE
WIP: Added Year, YearMonth and ArbitraryPrecisionDate

### DIFF
--- a/core/common/src/ArbitraryPrecisionDate.kt
+++ b/core/common/src/ArbitraryPrecisionDate.kt
@@ -1,0 +1,13 @@
+package kotlinx.datetime
+
+public sealed interface ArbitraryPrecisionDate : Comparable<ArbitraryPrecisionDate> {
+
+    public val year: Int
+
+    public companion object {
+
+        public fun parse(value: String): ArbitraryPrecisionDate {
+            TODO()
+        }
+    }
+}

--- a/core/common/src/Year.kt
+++ b/core/common/src/Year.kt
@@ -1,0 +1,7 @@
+package kotlinx.datetime
+
+public data class Year(override val year: Int) : ArbitraryPrecisionDate {
+
+    override fun compareTo(other: ArbitraryPrecisionDate): Int =
+        year.compareTo(other.year)
+}

--- a/core/common/src/YearMonth.kt
+++ b/core/common/src/YearMonth.kt
@@ -1,0 +1,8 @@
+package kotlinx.datetime
+
+public data class YearMonth(override val year: Int, public val month: Month) : ArbitraryPrecisionDate {
+
+    override fun compareTo(other: ArbitraryPrecisionDate): Int {
+        TODO("Not yet implemented")
+    }
+}


### PR DESCRIPTION
This is just a very quick example of how we could add support for an ArbitraryPrecisionDate that can be a `Year` or `YearMonth` or `LocalDate` or `LocalDateTime` or (later) `ZonedDateTime` (which could itself be a sealed class of `OffsetDateTime` and `RegionDateTime`).

The `ArbitraryPrecisionDate` could provide a `parse()` method that returns any of those classes (all of which implement ArbitraryPrecisionDate). At least in the medical space it's pretty common to have flexible date precisions in the official specifications, so you have to support at least these operations

* parsing
* machine-formatting back to the same precision string (so parsing results in the same object)
* human-formatting (displaying in the UI)
* sorting
* comparing

You might also want to treat the data differently based on its type. Here it helps a lot to have a sealed interface, so you can easily match all possible cases (which is also useful for the formatting and sorting etc. functions).

We could additionally have sealed interfaces for higher level subsets, so you can, for example, parse and work with any static type that contains at least a year-month-day.

What do you think?