### PR TITLE
WIP: Don't typealias Month

### DIFF
--- a/core/common/src/Month.kt
+++ b/core/common/src/Month.kt
@@ -7,7 +7,7 @@ package kotlinx.datetime
 
 import kotlin.native.concurrent.*
 
-public expect enum class Month {
+public enum class Month {
     JANUARY,
     FEBRUARY,
     MARCH,
@@ -21,10 +21,8 @@ public expect enum class Month {
     NOVEMBER,
     DECEMBER;
 
-//    val value: Int // member missing in java.time.Month has to be an extension
+    public val number: Int get() = ordinal + 1
 }
-
-public val Month.number: Int get() = ordinal + 1
 
 @SharedImmutable
 private val allMonths = Month.values().asList()

--- a/core/js/src/Month.kt
+++ b/core/js/src/Month.kt
@@ -7,19 +7,4 @@ package kotlinx.datetime
 
 import kotlinx.datetime.internal.JSJoda.Month as jsMonth
 
-public actual enum class Month {
-    JANUARY,
-    FEBRUARY,
-    MARCH,
-    APRIL,
-    MAY,
-    JUNE,
-    JULY,
-    AUGUST,
-    SEPTEMBER,
-    OCTOBER,
-    NOVEMBER,
-    DECEMBER;
-}
-
 internal fun jsMonth.toMonth(): Month = Month(this.value().toInt())

--- a/core/jvm/src/Converters.kt
+++ b/core/jvm/src/Converters.kt
@@ -6,6 +6,17 @@
 package kotlinx.datetime
 
 /**
+ * Converts this [kotlinx.datetime.Month][Month] value to a [java.time.Month][java.time.Month] value.
+ */
+public fun Month.toJavaMonth(): java.time.Month = java.time.Month.of(number)
+
+/**
+ * Converts this [java.time.Month][java.time.Month] value to a [kotlinx.datetime.Month][Month] value.
+ */
+public fun java.time.Month.toKotlinMonth(): Month = Month(value)
+
+
+/**
  * Converts this [kotlinx.datetime.Instant][Instant] value to a [java.time.Instant][java.time.Instant] value.
  */
 public fun Instant.toJavaInstant(): java.time.Instant = this.value

--- a/core/jvm/src/LocalDate.kt
+++ b/core/jvm/src/LocalDate.kt
@@ -36,7 +36,7 @@ public actual class LocalDate internal constructor(internal val value: jtLocalDa
 
     public actual val year: Int get() = value.year
     public actual val monthNumber: Int get() = value.monthValue
-    public actual val month: Month get() = value.month
+    public actual val month: Month get() = value.month.toKotlinMonth()
     public actual val dayOfMonth: Int get() = value.dayOfMonth
     public actual val dayOfWeek: DayOfWeek get() = value.dayOfWeek
     public actual val dayOfYear: Int get() = value.dayOfYear

--- a/core/jvm/src/LocalDateTime.kt
+++ b/core/jvm/src/LocalDateTime.kt
@@ -11,7 +11,6 @@ import java.time.DateTimeException
 import java.time.format.DateTimeParseException
 import java.time.LocalDateTime as jtLocalDateTime
 
-public actual typealias Month = java.time.Month
 public actual typealias DayOfWeek = java.time.DayOfWeek
 
 @Serializable(with = LocalDateTimeIso8601Serializer::class)
@@ -29,7 +28,7 @@ public actual class LocalDateTime internal constructor(internal val value: jtLoc
 
     public actual val year: Int get() = value.year
     public actual val monthNumber: Int get() = value.monthValue
-    public actual val month: Month get() = value.month
+    public actual val month: Month get() = value.month.toKotlinMonth()
     public actual val dayOfMonth: Int get() = value.dayOfMonth
     public actual val dayOfWeek: DayOfWeek get() = value.dayOfWeek
     public actual val dayOfYear: Int get() = value.dayOfYear

--- a/core/native/src/Month.kt
+++ b/core/native/src/Month.kt
@@ -5,10 +5,6 @@
 
 package kotlinx.datetime
 
-public actual enum class Month {
-    JANUARY, FEBRUARY, MARCH, APRIL, MAY, JUNE, JULY, AUGUST, SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER;
-}
-
 // From threetenbp
 internal fun Month.firstDayOfYear(leapYear: Boolean): Int {
     val leap = if (leapYear) 1 else 0


### PR DESCRIPTION
This is just one example from the codebase. Why are so many APIs `expect` and why do we even try to use `typealias` at all? This makes it more difficult to define a nice API for Kotlin and it causes lots of code repetition. It's even impossible to use `sealed interface/class` with `expect/actual` because the multiplatform code lives in different modules (see #173, #177  and #175 for how this can be useful).

I think it would be much better to separate the `expect` APIs and make them `internal` and expose a nice and clear non-expect based `public` API (which can call the `internal expect` API inside).

What do you think?