### PR TITLE
Add LocalDate to NSDate and LocalDateTime to NSDate conversions

### DIFF
--- a/core/darwin/src/Converters.kt
+++ b/core/darwin/src/Converters.kt
@@ -71,10 +71,12 @@ public fun LocalDate.toNSDateComponents(): NSDateComponents {
 
 /**
  * Converts the given [LocalDate] to [NSDate].
+ *
+ * The date calculated from the current components using the stored calendar.
  */
-public fun LocalDate.toNSDate(): NSDate? {
+public fun LocalDate.toNSDate(calendar: NSCalendar): NSDate? {
     val components = toNSDateComponents()
-    components.calendar = NSCalendar.currentCalendar
+    components.calendar = calendar
     return components.date
 }
 
@@ -94,9 +96,11 @@ public fun LocalDateTime.toNSDateComponents(): NSDateComponents {
 
 /**
  * Converts the given [LocalDateTime] to [NSDate].
+ *
+ * The date calculated from the current components using the stored calendar.
  */
-public fun LocalDateTime.toNSDate(): NSDate? {
+public fun LocalDateTime.toNSDate(calendar: NSCalendar): NSDate? {
     val components = toNSDateComponents()
-    components.calendar = NSCalendar.currentCalendar
+    components.calendar = calendar
     return components.date
 }

--- a/core/darwin/src/Converters.kt
+++ b/core/darwin/src/Converters.kt
@@ -93,7 +93,7 @@ public fun LocalDateTime.toNSDateComponents(): NSDateComponents {
 }
 
 /**
- * Converts the given [LocalDate] to [NSDate].
+ * Converts the given [LocalDateTime] to [NSDate].
  */
 public fun LocalDateTime.toNSDate(): NSDate? {
     val components = toNSDateComponents()

--- a/core/darwin/src/Converters.kt
+++ b/core/darwin/src/Converters.kt
@@ -79,7 +79,7 @@ public fun LocalDate.toNSDate(): NSDate? {
 }
 
 /**
- * Converts the given [LocalDate] to [NSDateComponents].
+ * Converts the given [LocalDateTime] to [NSDateComponents].
  *
  * Of all the fields, only the bare minimum required for uniquely identifying the date and time are set.
  */

--- a/core/darwin/src/Converters.kt
+++ b/core/darwin/src/Converters.kt
@@ -70,6 +70,15 @@ public fun LocalDate.toNSDateComponents(): NSDateComponents {
 }
 
 /**
+ * Converts the given [LocalDate] to [NSDate].
+ */
+public fun LocalDate.toNSDate(): NSDate? {
+    val components = toNSDateComponents()
+    components.calendar = NSCalendar.currentCalendar
+    return components.date
+}
+
+/**
  * Converts the given [LocalDate] to [NSDateComponents].
  *
  * Of all the fields, only the bare minimum required for uniquely identifying the date and time are set.
@@ -81,4 +90,13 @@ public fun LocalDateTime.toNSDateComponents(): NSDateComponents {
     components.second = second.convert()
     components.nanosecond = nanosecond.convert()
     return components
+}
+
+/**
+ * Converts the given [LocalDate] to [NSDate].
+ */
+public fun LocalDateTime.toNSDate(): NSDate? {
+    val components = toNSDateComponents()
+    components.calendar = NSCalendar.currentCalendar
+    return components.date
 }

--- a/core/darwin/test/ConvertersTest.kt
+++ b/core/darwin/test/ConvertersTest.kt
@@ -84,12 +84,29 @@ class ConvertersTest {
     }
 
     @Test
+    fun localDateToNSDateTest() {
+        val date = LocalDate.parse("2019-02-04")
+        val nsDate = date.toNSDate()!!
+        val formatter = NSDateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        assertEquals("2019-02-04", formatter.stringFromDate(nsDate))
+    }
+
+    @Test
     fun localDateTimeToNSDateComponentsTest() {
         val str = "2019-02-04T23:59:30.543"
         val dateTime = LocalDateTime.parse(str)
         val components = dateTime.toNSDateComponents()
         components.timeZone = utc
         val nsDate = gregorian.dateFromComponents(components)!!
+        assertEquals(str + "Z", dateFormatter.stringFromDate(nsDate))
+    }
+
+    @Test
+    fun localDateTimeToNSDateTest() {
+        val str = "2019-02-04T23:59:30.543"
+        val dateTime = LocalDateTime.parse(str)
+        val nsDate = dateTime.toNSDate()!!
         assertEquals(str + "Z", dateFormatter.stringFromDate(nsDate))
     }
 

--- a/core/darwin/test/ConvertersTest.kt
+++ b/core/darwin/test/ConvertersTest.kt
@@ -86,7 +86,7 @@ class ConvertersTest {
     @Test
     fun localDateToNSDateTest() {
         val date = LocalDate.parse("2019-02-04")
-        val nsDate = date.toNSDate()!!
+        val nsDate = date.toNSDate(calendar = gregorian)!!
         val formatter = NSDateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         assertEquals("2019-02-04", formatter.stringFromDate(nsDate))
@@ -106,7 +106,7 @@ class ConvertersTest {
     fun localDateTimeToNSDateTest() {
         val str = "2019-02-04T23:59:30.543"
         val dateTime = LocalDateTime.parse(str)
-        val nsDate = dateTime.toNSDate()!!
+        val nsDate = dateTime.toNSDate(calendar = gregorian)!!
         assertEquals(str + "Z", dateFormatter.stringFromDate(nsDate))
     }
 


### PR DESCRIPTION
In iOS is much more convenient to work with NSDate than with NSDateComponents.
But currently there is no direct converters from `LocalDate`/`LocalDateTime` to `NSDate`.
This PR fixes that.