### PR TITLE
Rename 'Clock.todayAt' to 'Clock.todayIn'

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ by converting it to `LocalDateTime` and taking its `date` property.
 val now: Instant = Clock.System.now()
 val today: LocalDate = now.toLocalDateTime(TimeZone.currentSystemDefault()).date
 // or more short
-val today: LocalDate = Clock.System.todayAt(TimeZone.currentSystemDefault())
+val today: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault())
 ```
 Note, that today's date really depends on the time zone in which you're observing the current moment.
 

--- a/core/common/src/Clock.kt
+++ b/core/common/src/Clock.kt
@@ -33,8 +33,8 @@ public interface Clock {
 /**
  * Returns the current date at the given [time zone][timeZone], according to [this Clock][this].
  */
-public fun Clock.todayAt(timeZone: TimeZone): LocalDate =
-        now().toLocalDateTime(timeZone).date
+public fun Clock.todayIn(timeZone: TimeZone): LocalDate =
+    now().toLocalDateTime(timeZone).date
 
 /**
  * Returns a [TimeSource] that uses this [Clock] to mark a time instant and to find the amount of time elapsed since that mark.
@@ -52,3 +52,6 @@ private class InstantTimeMark(private val instant: Instant, private val clock: C
 
     override fun minus(duration: Duration): TimeMark = InstantTimeMark(instant - duration, clock)
 }
+
+@Deprecated("Use Clock.todayIn instead", ReplaceWith("this.todayIn(timeZone)"), DeprecationLevel.WARNING)
+public fun Clock.todayAt(timeZone: TimeZone): LocalDate = todayIn(timeZone)

--- a/core/common/test/LocalDateTest.kt
+++ b/core/common/test/LocalDateTest.kt
@@ -106,7 +106,7 @@ class LocalDateTest {
     @Test
     @Suppress("UNUSED_VARIABLE")
     fun tomorrow() {
-        val today = Clock.System.todayAt(TimeZone.currentSystemDefault())
+        val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
 
         val nextMonthPlusDay1 = today.plus(DateTimeUnit.MONTH).plus(1, DateTimeUnit.DAY)
         val nextMonthPlusDay2 = today + DatePeriod(months = 1, days = 1)


### PR DESCRIPTION
The other functions that accept a time zone use the word "in" in their names.