### PR TITLE
Provide a way for customization Dokka's HTML output 

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -347,6 +347,8 @@ val downloadWindowsZonesMapping by tasks.registering {
 }
 
 tasks.withType<AbstractDokkaLeafTask>().configureEach {
+    pluginsMapConfiguration.set(mapOf("org.jetbrains.dokka.base.DokkaBase" to """{ "templatesDir" : "${projectDir.toString().replace('\\', '/')}/dokka-templates" }"""))
+
     dokkaSourceSets.configureEach {
         // reportUndocumented.set(true) // much noisy output about `hashCode` and serializer encoders, decoders etc
         skipDeprecated.set(true)

--- a/core/dokka-templates/README.md
+++ b/core/dokka-templates/README.md
@@ -1,0 +1,12 @@
+# Dokka's template customization
+To provide unified navigation for all parts of [kotlinlang.org](https://kotlinlang.org/),
+the Kotlin Website Team uses this directory to place custom templates in this folder
+during the website build time on TeamCity.
+
+It is not practical to place these templates in the kotlinx-datetime repository because they change from time to time
+and aren't related to the library's release cycle.
+
+The folder is defined as a source for custom templates by the templatesDir property through Dokka's plugin configuration.
+
+[Here](https://kotlin.github.io/dokka/1.7.20-SNAPSHOT/user_guide/output-formats/html/#custom-html-pages), you can
+find more about the customization of Dokka's HTML output.


### PR DESCRIPTION
To provide a better user experience and consistency between all parts of kotlinlang.org, we customize the header and the footer parts of API reference docs generated by Dokka. 

Starting from the 1.6.20 version, Dokka supports the customization of HTML output. You can read about it [here](https://kotlin.github.io/dokka/1.6.20/user_guide/base-specific/frontend/#custom-html-pages).
To use this opportunity, we need a small preparation on your side.
These changes allow HTML customization for the Dokka template.
The rest we will do on our side. 