### PR TITLE
Add `java.time.Clock` converter

### DIFF
--- a/core/jvm/src/Converters.kt
+++ b/core/jvm/src/Converters.kt
@@ -93,3 +93,11 @@ public fun UtcOffset.toJavaZoneOffset(): java.time.ZoneOffset = this.zoneOffset
  */
 public fun java.time.ZoneOffset.toKotlinUtcOffset(): UtcOffset = UtcOffset(this)
 
+/**
+ * Converts this [java.time.Clock][java.time.Clock] to a [kotlinx.datetime.Clock][Clock].
+ */
+public fun java.time.Clock.toKotlinClock(): Clock = this.let {
+    object : Clock {
+        override fun now() = it.instant().toKotlinInstant()
+    }
+}

--- a/core/jvm/src/Converters.kt
+++ b/core/jvm/src/Converters.kt
@@ -96,8 +96,6 @@ public fun java.time.ZoneOffset.toKotlinUtcOffset(): UtcOffset = UtcOffset(this)
 /**
  * Converts this [java.time.Clock][java.time.Clock] to a [kotlinx.datetime.Clock][Clock].
  */
-public fun java.time.Clock.toKotlinClock(): Clock = this.let {
-    object : Clock {
-        override fun now() = it.instant().toKotlinInstant()
-    }
+public fun java.time.Clock.toKotlinClock(): Clock = object : Clock {
+    override fun now() = instant().toKotlinInstant()
 }

--- a/core/jvm/test/ConvertersTest.kt
+++ b/core/jvm/test/ConvertersTest.kt
@@ -196,6 +196,5 @@ class ConvertersTest {
 
         assertEquals(jtClock.instant().epochSecond, ktClock.now().epochSeconds)
         assertEquals(jtClock.instant().toEpochMilli(), ktClock.now().toEpochMilliseconds())
-        assertEquals(jtClock.instant().toEpochMilli(), ktClock.now().toEpochMilliseconds())
     }
 }

--- a/core/jvm/test/ConvertersTest.kt
+++ b/core/jvm/test/ConvertersTest.kt
@@ -187,4 +187,15 @@ class ConvertersTest {
         test("+08")
         test("-103030")
     }
+
+    @Test
+    fun clock() {
+        val jtInstant = java.time.Instant.parse("2023-02-07T12:46:52.13Z")
+        val jtClock = java.time.Clock.fixed(jtInstant, ZoneId.of("UTC"))
+        val ktClock = jtClock.toKotlinClock()
+
+        assertEquals(jtClock.instant().epochSecond, ktClock.now().epochSeconds)
+        assertEquals(jtClock.instant().toEpochMilli(), ktClock.now().toEpochMilliseconds())
+        assertEquals(jtClock.instant().toEpochMilli(), ktClock.now().toEpochMilliseconds())
+    }
 }


### PR DESCRIPTION
Adds a function to convert a `java.time.Clock` to a `kotlinx.datetime.Clock`.