### PR TITLE
Add all the supported Kotlin/Native targets that we can

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -37,24 +37,41 @@ kotlin {
     explicitApi()
 
     infra {
+        // Tiers are in accordance with <https://kotlinlang.org/docs/native-target-support.html>
+        // Tier 1
         target("linuxX64")
+        // Tier 2
+        target("linuxArm64")
+        // Tier 3
         target("mingwX64")
-
+        // the following targets are not supported by kotlinx.serialization:
+        /*
+        target("androidNativeArm32")
+        target("androidNativeArm64")
+        target("androidNativeX86")
+        target("androidNativeX64")
+         */
+        // Darwin targets are listed separately
         common("darwin") {
+            // Tier 1
             target("macosX64")
             target("macosArm64")
-            target("iosX64")
-            target("iosArm64")
-            target("iosArm32")
             target("iosSimulatorArm64")
+            target("iosX64")
+            // Tier 2
+            target("watchosSimulatorArm64")
+            target("watchosX64")
             target("watchosArm32")
             target("watchosArm64")
-            target("watchosX86")
-            target("watchosX64")
-            target("watchosSimulatorArm64")
-            target("tvosArm64")
-            target("tvosX64")
             target("tvosSimulatorArm64")
+            target("tvosX64")
+            target("tvosArm64")
+            target("iosArm64")
+            // Tier 3
+            // target("watchosDeviceArm64") // not supported by kotlinx.serialization
+            // Deprecated for removal
+            target("iosArm32")
+            target("watchosX86")
         }
     }
 


### PR DESCRIPTION
Only the Android NDK and the non-ILP32 WatchOS Arm64 targets are not supported, as we depend on the serialization library, which also doesn't support them.

Fixes #165