### PR TITLE
Fix adding small `Duration` to large `Instant` on JS and Native

### DIFF
--- a/core/common/test/InstantTest.kt
+++ b/core/common/test/InstantTest.kt
@@ -609,4 +609,13 @@ class InstantRangeTest {
         (maxValidInstant + 1.nanoseconds).until(maxValidInstant, DateTimeUnit.NANOSECOND)
         maxValidInstant.until(maxValidInstant + 1.nanoseconds, DateTimeUnit.NANOSECOND)
     }
+
+    // https://github.com/Kotlin/kotlinx-datetime/issues/263
+    @Test
+    fun addSmallDurationsToLargeInstants() {
+        for (smallDuration in listOf(1.nanoseconds, 999_999.nanoseconds, 1.seconds - 1.nanoseconds)) {
+            assertEquals(expected = Instant.MAX, actual = Instant.MAX + smallDuration)
+            assertEquals(expected = Instant.MIN, actual = Instant.MIN - smallDuration)
+        }
+    }
 }

--- a/core/js/src/Instant.kt
+++ b/core/js/src/Instant.kt
@@ -35,7 +35,7 @@ public actual class Instant internal constructor(internal val value: jtInstant) 
             Instant(plusFix(seconds.toDouble(), nanoseconds))
         } catch (e: Throwable) {
             if (!e.isJodaDateTimeException()) throw e
-            if (seconds > 0) MAX else MIN
+            if (duration.isPositive()) MAX else MIN
         }
     }
 

--- a/core/native/src/Instant.kt
+++ b/core/native/src/Instant.kt
@@ -159,9 +159,9 @@ public actual class Instant internal constructor(public actual val epochSeconds:
         try {
             plus(secondsToAdd, nanosecondsToAdd.toLong())
         } catch (e: IllegalArgumentException) {
-            if (secondsToAdd > 0) MAX else MIN
+            if (duration.isPositive()) MAX else MIN
         } catch (e: ArithmeticException) {
-            if (secondsToAdd > 0) MAX else MIN
+            if (duration.isPositive()) MAX else MIN
         }
     }
 


### PR DESCRIPTION
When adding a positive `Duration` < 1 second to an `Instant` far in the future for which the addition implementation overflows and throws an exception, the `catch` blocks would only check if the `seconds` component of the `Duration` is `> 0`. However since the `Duration` is < 1 second, the `seconds` component is not `> 0` and `Instant.MIN` is returned instead of `Instant.MAX`.

This was fixed by replacing the check against the seconds component of the `Duration` with a check against the whole `Duration` like it was already done in the JVM implementation.

fixes #263