### PR TITLE
Adding Clock lambda helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![JetBrains official project](https://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub) 
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx/kotlinx-datetime.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22org.jetbrains.kotlinx%22%20AND%20a:%22kotlinx-datetime%22)
-[![Kotlin](https://img.shields.io/badge/kotlin-1.7.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-1.8.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![KDoc link](https://img.shields.io/badge/API_reference-KDoc-blue)](https://kotlinlang.org/api/kotlinx-datetime/)
 [![Slack channel](https://img.shields.io/badge/chat-slack-blue.svg?logo=slack)](https://kotlinlang.slack.com/messages/kotlinx-datetime/)
 [![TeamCity build](https://img.shields.io/teamcity/build/s/KotlinTools_KotlinxDatetime_Build_All.svg?server=http%3A%2F%2Fteamcity.jetbrains.com)](https://teamcity.jetbrains.com/viewType.html?buildTypeId=KotlinTools_KotlinxDatetime_Build_All&guest=1)

--- a/core/common/src/Clock.kt
+++ b/core/common/src/Clock.kt
@@ -31,7 +31,7 @@ public interface Clock {
 }
 
 /**
- * 
+ * Helper function to create a [Clock] instance with a custom [Instant] provider lambda.
  */
 public fun Clock(instantProvider: () -> Instant): Clock = object : Clock {
     override fun now(): Instant = instantProvider.invoke()

--- a/core/common/src/Clock.kt
+++ b/core/common/src/Clock.kt
@@ -31,6 +31,13 @@ public interface Clock {
 }
 
 /**
+ * 
+ */
+public fun Clock(instantProvider: () -> Instant): Clock = object : Clock {
+    override fun now(): Instant = instantProvider.invoke()
+}
+
+/**
  * Returns the current date at the given [time zone][timeZone], according to [this Clock][this].
  */
 public fun Clock.todayIn(timeZone: TimeZone): LocalDate =

--- a/core/common/test/ClockTimeSourceTest.kt
+++ b/core/common/test/ClockTimeSourceTest.kt
@@ -29,21 +29,19 @@ class ClockTimeSourceTest {
 
     @Test
     fun elapsed() {
-        val clock = object : Clock {
-            var instant = Clock.System.now()
-            override fun now(): Instant = instant
-        }
+        var instant = Clock.System.now()
+        val clock = Clock { instant }
         val timeSource = clock.asTimeSource()
         val mark = timeSource.markNow()
         assertEquals(Duration.ZERO, mark.elapsedNow())
 
-        clock.instant += 1.days
+        instant += 1.days
         assertEquals(1.days, mark.elapsedNow())
 
-        clock.instant -= 2.days
-        assertEquals(-1.days, mark.elapsedNow())
+        instant -= 2.days
+        assertEquals((-1).days, mark.elapsedNow())
 
-        clock.instant = Instant.MAX
+        instant = Instant.MAX
         assertEquals(Duration.INFINITE, mark.elapsedNow())
     }
 


### PR DESCRIPTION
Added helper function to create a Clock instance by passing in a lambda to be invoked for Clock.now(); Updated Kotlin shield in README to reflect usage of version 1.8.10

Fixes #273