### PR TITLE
Make helper_macros.hpp self-contained.

### DIFF
--- a/core/native/cinterop/public/helper_macros.hpp
+++ b/core/native/cinterop/public/helper_macros.hpp
@@ -3,6 +3,8 @@
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 #pragma once
+#include <cstddef>
+#include <cstdio>
 #include <cstdlib>
 
 /* Check the given pointer to see if it's null. If so, fail, printing to


### PR DESCRIPTION
Previously this header relied on include order to work correctly, as it didn't include all required headers.