### PR TITLE
Set timezone on NSDateFormatter explicitly

### DIFF
--- a/core/darwin/test/ConvertersTest.kt
+++ b/core/darwin/test/ConvertersTest.kt
@@ -79,6 +79,7 @@ class ConvertersTest {
         components.timeZone = utc
         val nsDate = gregorian.dateFromComponents(components)!!
         val formatter = NSDateFormatter()
+        formatter.timeZone = utc
         formatter.dateFormat = "yyyy-MM-dd"
         assertEquals("2019-02-04", formatter.stringFromDate(nsDate))
     }


### PR DESCRIPTION
Fix test case in US timezones by explicitly formatting date with the UTC timezone