### PR TITLE
Prevent secondary outputs of Java 9 compilation getting packed into jar

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -290,7 +290,7 @@ tasks {
         manifest {
             attributes("Multi-Release" to true)
         }
-        from(compileJavaModuleInfo) {
+        from(compileJavaModuleInfo.map { it.destinationDirectory }) {
             into("META-INF/versions/9/")
         }
     }


### PR DESCRIPTION
Fixes #304