### PR TITLE
Reduce the number of suppressions for internal access 

### DIFF
--- a/core/common/src/serializers/DateTimePeriodSerializers.kt
+++ b/core/common/src/serializers/DateTimePeriodSerializers.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.encoding.*
 public object DateTimePeriodComponentSerializer: KSerializer<DateTimePeriod> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("DateTimePeriod") {
+        buildClassSerialDescriptor("kotlinx.datetime.DateTimePeriod") {
             element<Int>("years", isOptional = true)
             element<Int>("months", isOptional = true)
             element<Int>("days", isOptional = true)
@@ -81,7 +81,7 @@ public object DateTimePeriodComponentSerializer: KSerializer<DateTimePeriod> {
 public object DateTimePeriodIso8601Serializer: KSerializer<DateTimePeriod> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("DateTimePeriod", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.datetime.DateTimePeriod", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): DateTimePeriod =
         DateTimePeriod.parse(decoder.decodeString())
@@ -110,7 +110,7 @@ public object DatePeriodComponentSerializer: KSerializer<DatePeriod> {
     private fun unexpectedNonzero(fieldName: String, value: Int) = unexpectedNonzero(fieldName, value.toLong())
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("DatePeriod") {
+        buildClassSerialDescriptor("kotlinx.datetime.DatePeriod") {
             element<Int>("years", isOptional = true)
             element<Int>("months", isOptional = true)
             element<Int>("days", isOptional = true)
@@ -166,7 +166,7 @@ public object DatePeriodComponentSerializer: KSerializer<DatePeriod> {
 public object DatePeriodIso8601Serializer: KSerializer<DatePeriod> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("DatePeriod", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.datetime.DatePeriod", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): DatePeriod =
         when (val period = DateTimePeriod.parse(decoder.decodeString())) {

--- a/core/common/src/serializers/DateTimeUnitSerializers.kt
+++ b/core/common/src/serializers/DateTimeUnitSerializers.kt
@@ -23,7 +23,7 @@ public object TimeBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.TimeBase
 
     // https://youtrack.jetbrains.com/issue/KT-63939
     override val descriptor: SerialDescriptor by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        buildClassSerialDescriptor("TimeBased") {
+        buildClassSerialDescriptor("kotlinx.datetime.TimeBased") {
             element<Long>("nanoseconds")
         }
     }
@@ -69,7 +69,7 @@ public object DayBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.DayBased>
 
     // https://youtrack.jetbrains.com/issue/KT-63939
     override val descriptor: SerialDescriptor by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        buildClassSerialDescriptor("DayBased") {
+        buildClassSerialDescriptor("kotlinx.datetime.DayBased") {
             element<Int>("days")
         }
     }
@@ -115,7 +115,7 @@ public object MonthBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.MonthBa
 
     // https://youtrack.jetbrains.com/issue/KT-63939
     override val descriptor: SerialDescriptor by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        buildClassSerialDescriptor("MonthBased") {
+        buildClassSerialDescriptor("kotlinx.datetime.MonthBased") {
             element<Int>("months")
         }
     }

--- a/core/common/src/serializers/DateTimeUnitSerializers.kt
+++ b/core/common/src/serializers/DateTimeUnitSerializers.kt
@@ -101,7 +101,7 @@ public object DayBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.DayBased>
                 }
             }
         }
-        if (!seen) throw MissingFieldException(missingField = "days", serialName = TimeBasedDateTimeUnitSerializer.descriptor.serialName)
+        if (!seen) throw MissingFieldException(missingField = "days", serialName = descriptor.serialName)
         return DateTimeUnit.DayBased(days)
     }
 }

--- a/core/common/src/serializers/DateTimeUnitSerializers.kt
+++ b/core/common/src/serializers/DateTimeUnitSerializers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 JetBrains s.r.o.
+ * Copyright 2019-2023 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
@@ -35,7 +35,6 @@ public object TimeBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.TimeBase
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    @Suppress("INVISIBLE_MEMBER") // to be able to throw `MissingFieldException`
     override fun deserialize(decoder: Decoder): DateTimeUnit.TimeBased {
         var seen = false
         var nanoseconds = 0L
@@ -51,12 +50,12 @@ public object TimeBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.TimeBase
                             seen = true
                         }
                         CompositeDecoder.DECODE_DONE -> break@loop // https://youtrack.jetbrains.com/issue/KT-42262
-                        else -> throw UnknownFieldException(elementIndex)
+                        else -> throwUnknownIndexException(elementIndex)
                     }
                 }
             }
         }
-        if (!seen) throw MissingFieldException("nanoseconds")
+        if (!seen) throw MissingFieldException(missingField = "nanoseconds", serialName = descriptor.serialName)
         return DateTimeUnit.TimeBased(nanoseconds)
     }
 }
@@ -82,7 +81,6 @@ public object DayBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.DayBased>
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    @Suppress("INVISIBLE_MEMBER") // to be able to throw `MissingFieldException`
     override fun deserialize(decoder: Decoder): DateTimeUnit.DayBased {
         var seen = false
         var days = 0
@@ -98,12 +96,12 @@ public object DayBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.DayBased>
                             seen = true
                         }
                         CompositeDecoder.DECODE_DONE -> break@loop // https://youtrack.jetbrains.com/issue/KT-42262
-                        else -> throw UnknownFieldException(elementIndex)
+                        else -> throwUnknownIndexException(elementIndex)
                     }
                 }
             }
         }
-        if (!seen) throw MissingFieldException("days")
+        if (!seen) throw MissingFieldException(missingField = "days", serialName = TimeBasedDateTimeUnitSerializer.descriptor.serialName)
         return DateTimeUnit.DayBased(days)
     }
 }
@@ -129,7 +127,6 @@ public object MonthBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.MonthBa
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    @Suppress("INVISIBLE_MEMBER") // to be able to throw `MissingFieldException`
     override fun deserialize(decoder: Decoder): DateTimeUnit.MonthBased {
         var seen = false
         var months = 0
@@ -145,12 +142,12 @@ public object MonthBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.MonthBa
                             seen = true
                         }
                         CompositeDecoder.DECODE_DONE -> break@loop // https://youtrack.jetbrains.com/issue/KT-42262
-                        else -> throw UnknownFieldException(elementIndex)
+                        else -> throwUnknownIndexException(elementIndex)
                     }
                 }
             }
         }
-        if (!seen) throw MissingFieldException("months")
+        if (!seen) throw MissingFieldException(missingField = "months", serialName = descriptor.serialName)
         return DateTimeUnit.MonthBased(months)
     }
 }
@@ -160,7 +157,7 @@ public object MonthBasedDateTimeUnitSerializer: KSerializer<DateTimeUnit.MonthBa
  *
  * JSON example: `{"type":"DayBased","days":15}`
  */
-@Suppress("EXPERIMENTAL_API_USAGE_ERROR", "INVISIBLE_MEMBER")
+@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE") // https://github.com/Kotlin/kotlinx.serialization/issues/2460
 @OptIn(InternalSerializationApi::class)
 public object DateBasedDateTimeUnitSerializer: AbstractPolymorphicSerializer<DateTimeUnit.DateBased>() {
 
@@ -197,9 +194,9 @@ public object DateBasedDateTimeUnitSerializer: AbstractPolymorphicSerializer<Dat
  *
  * JSON example: `{"type":"MonthBased","days":15}`
  */
-@Suppress("EXPERIMENTAL_API_USAGE_ERROR", "INVISIBLE_MEMBER")
+@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE") // https://github.com/Kotlin/kotlinx.serialization/issues/2460
 @OptIn(InternalSerializationApi::class)
-public object DateTimeUnitSerializer: AbstractPolymorphicSerializer<DateTimeUnit>() {
+public object DateTimeUnitSerializer : AbstractPolymorphicSerializer<DateTimeUnit>() {
 
     // https://youtrack.jetbrains.com/issue/KT-63939
     private val impl by lazy(LazyThreadSafetyMode.PUBLICATION) {
@@ -224,4 +221,8 @@ public object DateTimeUnitSerializer: AbstractPolymorphicSerializer<DateTimeUnit
     override val descriptor: SerialDescriptor
         get() = impl.descriptor
 
+}
+
+internal fun throwUnknownIndexException(index: Int): Nothing {
+    throw SerializationException("An unknown field for index $index")
 }

--- a/core/common/src/serializers/DayOfWeekSerializers.kt
+++ b/core/common/src/serializers/DayOfWeekSerializers.kt
@@ -16,7 +16,8 @@ import kotlinx.serialization.internal.*
  *
  * JSON example: `"MONDAY"`
  */
+@Suppress("EnumValuesSoftDeprecate") // createEnumSerializer requires an array
 public object DayOfWeekSerializer : KSerializer<DayOfWeek> by createEnumSerializer<DayOfWeek>(
-    "kotlinx.datetime.serializers.DayOfWeek",
+    "kotlinx.datetime.DayOfWeek",
     DayOfWeek.values()
 )

--- a/core/common/src/serializers/DayOfWeekSerializers.kt
+++ b/core/common/src/serializers/DayOfWeekSerializers.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019-2021 JetBrains s.r.o.
+ * Copyright 2019-2023 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
 package kotlinx.datetime.serializers
 
-import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.*
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
@@ -16,14 +16,7 @@ import kotlinx.serialization.internal.*
  *
  * JSON example: `"MONDAY"`
  */
-@Suppress("INVISIBLE_MEMBER")
-public object DayOfWeekSerializer: KSerializer<DayOfWeek> {
-    private val impl = EnumSerializer("Month", DayOfWeek.values())
-
-    override val descriptor: SerialDescriptor
-        get() = impl.descriptor
-
-    override fun deserialize(decoder: Decoder): DayOfWeek = impl.deserialize(decoder)
-
-    override fun serialize(encoder: Encoder, value: DayOfWeek): Unit = impl.serialize(encoder, value)
-}
+public object DayOfWeekSerializer : KSerializer<DayOfWeek> by createEnumSerializer<DayOfWeek>(
+    "kotlinx.datetime.serializers.DayOfWeek",
+    DayOfWeek.values()
+)

--- a/core/common/src/serializers/InstantSerializers.kt
+++ b/core/common/src/serializers/InstantSerializers.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.encoding.*
 public object InstantIso8601Serializer : KSerializer<Instant> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("Instant", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.datetime.Instant", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): Instant =
         Instant.parse(decoder.decodeString())
@@ -40,7 +40,7 @@ public object InstantIso8601Serializer : KSerializer<Instant> {
 public object InstantComponentSerializer : KSerializer<Instant> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("Instant") {
+        buildClassSerialDescriptor("kotlinx.datetime.Instant") {
             element<Long>("epochSeconds")
             element<Long>("nanosecondsOfSecond", isOptional = true)
         }

--- a/core/common/src/serializers/InstantSerializers.kt
+++ b/core/common/src/serializers/InstantSerializers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 JetBrains s.r.o.
+ * Copyright 2019-2023 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
@@ -18,7 +18,7 @@ import kotlinx.serialization.encoding.*
  * @see Instant.toString
  * @see Instant.parse
  */
-public object InstantIso8601Serializer: KSerializer<Instant> {
+public object InstantIso8601Serializer : KSerializer<Instant> {
 
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("Instant", PrimitiveKind.STRING)
@@ -37,7 +37,7 @@ public object InstantIso8601Serializer: KSerializer<Instant> {
  *
  * JSON example: `{"epochSeconds":1607505416,"nanosecondsOfSecond":124000}`
  */
-public object InstantComponentSerializer: KSerializer<Instant> {
+public object InstantComponentSerializer : KSerializer<Instant> {
 
     override val descriptor: SerialDescriptor =
         buildClassSerialDescriptor("Instant") {
@@ -46,12 +46,11 @@ public object InstantComponentSerializer: KSerializer<Instant> {
         }
 
     @OptIn(ExperimentalSerializationApi::class)
-    @Suppress("INVISIBLE_MEMBER") // to be able to throw `MissingFieldException`
     override fun deserialize(decoder: Decoder): Instant =
         decoder.decodeStructure(descriptor) {
             var epochSeconds: Long? = null
             var nanosecondsOfSecond = 0
-            loop@while (true) {
+            loop@ while (true) {
                 when (val index = decodeElementIndex(descriptor)) {
                     0 -> epochSeconds = decodeLongElement(descriptor, 0)
                     1 -> nanosecondsOfSecond = decodeIntElement(descriptor, 1)
@@ -59,7 +58,10 @@ public object InstantComponentSerializer: KSerializer<Instant> {
                     else -> throw SerializationException("Unexpected index: $index")
                 }
             }
-            if (epochSeconds == null) throw MissingFieldException("epochSeconds")
+            if (epochSeconds == null) throw MissingFieldException(
+                missingField = "epochSeconds",
+                serialName = descriptor.serialName
+            )
             Instant.fromEpochSeconds(epochSeconds, nanosecondsOfSecond)
         }
 

--- a/core/common/src/serializers/LocalDateSerializers.kt
+++ b/core/common/src/serializers/LocalDateSerializers.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.encoding.*
 public object LocalDateIso8601Serializer: KSerializer<LocalDate> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("LocalDate", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.datetime.LocalDate", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): LocalDate =
         LocalDate.parse(decoder.decodeString())
@@ -40,7 +40,7 @@ public object LocalDateIso8601Serializer: KSerializer<LocalDate> {
 public object LocalDateComponentSerializer: KSerializer<LocalDate> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("LocalDate") {
+        buildClassSerialDescriptor("kotlinx.datetime.LocalDate") {
             element<Int>("year")
             element<Short>("month")
             element<Short>("day")

--- a/core/common/src/serializers/LocalDateSerializers.kt
+++ b/core/common/src/serializers/LocalDateSerializers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 JetBrains s.r.o.
+ * Copyright 2019-2023 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
@@ -47,7 +47,6 @@ public object LocalDateComponentSerializer: KSerializer<LocalDate> {
         }
 
     @OptIn(ExperimentalSerializationApi::class)
-    @Suppress("INVISIBLE_MEMBER") // to be able to throw `MissingFieldException`
     override fun deserialize(decoder: Decoder): LocalDate =
         decoder.decodeStructure(descriptor) {
             var year: Int? = null
@@ -59,12 +58,12 @@ public object LocalDateComponentSerializer: KSerializer<LocalDate> {
                     1 -> month = decodeShortElement(descriptor, 1)
                     2 -> day = decodeShortElement(descriptor, 2)
                     CompositeDecoder.DECODE_DONE -> break@loop // https://youtrack.jetbrains.com/issue/KT-42262
-                    else -> throw SerializationException("Unexpected index: $index")
+                    else -> throwUnknownIndexException(index)
                 }
             }
-            if (year == null) throw MissingFieldException("year")
-            if (month == null) throw MissingFieldException("month")
-            if (day == null) throw MissingFieldException("day")
+            if (year == null) throw MissingFieldException(missingField = "year", serialName = descriptor.serialName)
+            if (month == null) throw MissingFieldException(missingField = "month", serialName = descriptor.serialName)
+            if (day == null) throw MissingFieldException(missingField = "day", serialName = descriptor.serialName)
             LocalDate(year, month.toInt(), day.toInt())
         }
 

--- a/core/common/src/serializers/LocalDateTimeSerializers.kt
+++ b/core/common/src/serializers/LocalDateTimeSerializers.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.encoding.*
 public object LocalDateTimeIso8601Serializer: KSerializer<LocalDateTime> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.datetime.LocalDateTime", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): LocalDateTime =
         LocalDateTime.parse(decoder.decodeString())
@@ -40,7 +40,7 @@ public object LocalDateTimeIso8601Serializer: KSerializer<LocalDateTime> {
 public object LocalDateTimeComponentSerializer: KSerializer<LocalDateTime> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("LocalDateTime") {
+        buildClassSerialDescriptor("kotlinx.datetime.LocalDateTime") {
             element<Int>("year")
             element<Short>("month")
             element<Short>("day")

--- a/core/common/src/serializers/LocalDateTimeSerializers.kt
+++ b/core/common/src/serializers/LocalDateTimeSerializers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 JetBrains s.r.o.
+ * Copyright 2019-2023 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
@@ -51,7 +51,6 @@ public object LocalDateTimeComponentSerializer: KSerializer<LocalDateTime> {
         }
 
     @OptIn(ExperimentalSerializationApi::class)
-    @Suppress("INVISIBLE_MEMBER") // to be able to throw `MissingFieldException`
     override fun deserialize(decoder: Decoder): LocalDateTime =
         decoder.decodeStructure(descriptor) {
             var year: Int? = null
@@ -74,11 +73,11 @@ public object LocalDateTimeComponentSerializer: KSerializer<LocalDateTime> {
                     else -> throw SerializationException("Unexpected index: $index")
                 }
             }
-            if (year == null) throw MissingFieldException("year")
-            if (month == null) throw MissingFieldException("month")
-            if (day == null) throw MissingFieldException("day")
-            if (hour == null) throw MissingFieldException("hour")
-            if (minute == null) throw MissingFieldException("minute")
+            if (year == null) throw MissingFieldException(missingField = "year", serialName = descriptor.serialName)
+            if (month == null) throw MissingFieldException(missingField = "month", serialName = descriptor.serialName)
+            if (day == null) throw MissingFieldException(missingField = "day", serialName = descriptor.serialName)
+            if (hour == null) throw MissingFieldException(missingField = "hour", serialName = descriptor.serialName)
+            if (minute == null) throw MissingFieldException(missingField = "minute", serialName = descriptor.serialName)
             LocalDateTime(year, month.toInt(), day.toInt(), hour.toInt(), minute.toInt(), second.toInt(), nanosecond)
         }
 

--- a/core/common/src/serializers/LocalTimeSerializers.kt
+++ b/core/common/src/serializers/LocalTimeSerializers.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.encoding.*
 public object LocalTimeIso8601Serializer : KSerializer<LocalTime> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("LocalTime", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.datetime.LocalTime", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): LocalTime =
         LocalTime.parse(decoder.decodeString())
@@ -39,7 +39,7 @@ public object LocalTimeIso8601Serializer : KSerializer<LocalTime> {
 public object LocalTimeComponentSerializer : KSerializer<LocalTime> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("LocalTime") {
+        buildClassSerialDescriptor("kotlinx.datetime.LocalTime") {
             element<Short>("hour")
             element<Short>("minute")
             element<Short>("second", isOptional = true)

--- a/core/common/src/serializers/LocalTimeSerializers.kt
+++ b/core/common/src/serializers/LocalTimeSerializers.kt
@@ -47,7 +47,6 @@ public object LocalTimeComponentSerializer : KSerializer<LocalTime> {
         }
 
     @OptIn(ExperimentalSerializationApi::class)
-    @Suppress("INVISIBLE_MEMBER") // to be able to throw `MissingFieldException`
     override fun deserialize(decoder: Decoder): LocalTime =
         decoder.decodeStructure(descriptor) {
             var hour: Short? = null
@@ -64,8 +63,8 @@ public object LocalTimeComponentSerializer : KSerializer<LocalTime> {
                     else -> throw SerializationException("Unexpected index: $index")
                 }
             }
-            if (hour == null) throw MissingFieldException("hour")
-            if (minute == null) throw MissingFieldException("minute")
+            if (hour == null) throw MissingFieldException(missingField = "hour", serialName = descriptor.serialName)
+            if (minute == null) throw MissingFieldException(missingField = "minute", serialName = descriptor.serialName)
             LocalTime(hour.toInt(), minute.toInt(), second.toInt(), nanosecond)
         }
 

--- a/core/common/src/serializers/MonthSerializers.kt
+++ b/core/common/src/serializers/MonthSerializers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 JetBrains s.r.o.
+ * Copyright 2019-2023 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
@@ -16,14 +16,12 @@ import kotlinx.serialization.internal.*
  *
  * JSON example: `"JANUARY"`
  */
-@Suppress("INVISIBLE_MEMBER")
-public object MonthSerializer: KSerializer<Month> {
-    private val impl = EnumSerializer("Month", Month.values())
+public object MonthSerializer : KSerializer<Month> by createEnumSerializer<Month>(
+    "kotlinx.datetime.serializers.Month",
+    Month.values())
 
-    override val descriptor: SerialDescriptor
-        get() = impl.descriptor
-
-    override fun deserialize(decoder: Decoder): Month = impl.deserialize(decoder)
-
-    override fun serialize(encoder: Encoder, value: Month): Unit = impl.serialize(encoder, value)
+// Until https://github.com/Kotlin/kotlinx.serialization/issues/2459 is resolved
+internal fun <E : Enum<E>> createEnumSerializer(serialName: String, values: Array<E>): KSerializer<E> {
+    @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+    return kotlinx.serialization.internal.EnumSerializer(serialName, values)
 }

--- a/core/common/src/serializers/MonthSerializers.kt
+++ b/core/common/src/serializers/MonthSerializers.kt
@@ -16,8 +16,9 @@ import kotlinx.serialization.internal.*
  *
  * JSON example: `"JANUARY"`
  */
+@Suppress("EnumValuesSoftDeprecate") // createEnumSerializer requires an array
 public object MonthSerializer : KSerializer<Month> by createEnumSerializer<Month>(
-    "kotlinx.datetime.serializers.Month",
+    "kotlinx.datetime.Month",
     Month.values())
 
 // Until https://github.com/Kotlin/kotlinx.serialization/issues/2459 is resolved

--- a/core/common/src/serializers/TimeZoneSerializers.kt
+++ b/core/common/src/serializers/TimeZoneSerializers.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.encoding.*
  */
 public object TimeZoneSerializer: KSerializer<TimeZone> {
 
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("TimeZone", PrimitiveKind.STRING)
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("kotlinx.datetime.TimeZone", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): TimeZone = TimeZone.of(decoder.decodeString())
 
@@ -36,7 +36,7 @@ public object TimeZoneSerializer: KSerializer<TimeZone> {
  */
 public object FixedOffsetTimeZoneSerializer: KSerializer<FixedOffsetTimeZone> {
 
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("FixedOffsetTimeZone", PrimitiveKind.STRING)
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("kotlinx.datetime.FixedOffsetTimeZone", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): FixedOffsetTimeZone {
         val zone = TimeZone.of(decoder.decodeString())
@@ -63,7 +63,7 @@ public object FixedOffsetTimeZoneSerializer: KSerializer<FixedOffsetTimeZone> {
  */
 public object UtcOffsetSerializer: KSerializer<UtcOffset> {
 
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UtcOffset", PrimitiveKind.STRING)
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("kotlinx.datetime.UtcOffset", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): UtcOffset {
         return UtcOffset.parse(decoder.decodeString())

--- a/serialization/common/test/DateTimeUnitSerializationTest.kt
+++ b/serialization/common/test/DateTimeUnitSerializationTest.kt
@@ -48,14 +48,14 @@ class DateTimeUnitSerializationTest {
         repeat(100) {
             val days = Random.nextInt(1, Int.MAX_VALUE)
             val unit = DateTimeUnit.DayBased(days)
-            val json = "{\"type\":\"DayBased\",\"days\":$days}"
+            val json = "{\"type\":\"kotlinx.datetime.DayBased\",\"days\":$days}"
             assertEquals(json, Json.encodeToString(serializer, unit))
             assertEquals(unit, Json.decodeFromString(serializer, json))
         }
         repeat(100) {
             val months = Random.nextInt(1, Int.MAX_VALUE)
             val unit = DateTimeUnit.MonthBased(months)
-            val json = "{\"type\":\"MonthBased\",\"months\":$months}"
+            val json = "{\"type\":\"kotlinx.datetime.MonthBased\",\"months\":$months}"
             assertEquals(json, Json.encodeToString(serializer, unit))
             assertEquals(unit, Json.decodeFromString(serializer, json))
         }
@@ -65,21 +65,21 @@ class DateTimeUnitSerializationTest {
         repeat(100) {
             val nanoseconds = Random.nextLong(1, Long.MAX_VALUE)
             val unit = DateTimeUnit.TimeBased(nanoseconds)
-            val json = "{\"type\":\"TimeBased\",\"nanoseconds\":${nanoseconds.toString()}}" // https://youtrack.jetbrains.com/issue/KT-39891
+            val json = "{\"type\":\"kotlinx.datetime.TimeBased\",\"nanoseconds\":${nanoseconds.toString()}}" // https://youtrack.jetbrains.com/issue/KT-39891
             assertEquals(json, Json.encodeToString(serializer, unit))
             assertEquals(unit, Json.decodeFromString(serializer, json))
         }
         repeat(100) {
             val days = Random.nextInt(1, Int.MAX_VALUE)
             val unit = DateTimeUnit.DayBased(days)
-            val json = "{\"type\":\"DayBased\",\"days\":$days}"
+            val json = "{\"type\":\"kotlinx.datetime.DayBased\",\"days\":$days}"
             assertEquals(json, Json.encodeToString(serializer, unit))
             assertEquals(unit, Json.decodeFromString(serializer, json))
         }
         repeat(100) {
             val months = Random.nextInt(1, Int.MAX_VALUE)
             val unit = DateTimeUnit.MonthBased(months)
-            val json = "{\"type\":\"MonthBased\",\"months\":$months}"
+            val json = "{\"type\":\"kotlinx.datetime.MonthBased\",\"months\":$months}"
             assertEquals(json, Json.encodeToString(serializer, unit))
             assertEquals(unit, Json.decodeFromString(serializer, json))
         }


### PR DESCRIPTION
While backporting K2 commits, I've spotted one related to `internal` declarations.

Instead of backporting it, I decided to tide it up in the face of https://youtrack.jetbrains.com/issue/KT-60866/Phase-out-usages-of-SuppressINVISIBLEREFERENCE-INVISIBLEMEMBER-in-libraries