### PR TITLE
Enable binary compatibility validation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("kotlinx.team.infra") version "0.4.0-dev-80"
     kotlin("multiplatform") apply false
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
 }
 
 infra {

--- a/core/api/kotlinx-datetime.api
+++ b/core/api/kotlinx-datetime.api
@@ -1,0 +1,623 @@
+public abstract interface class kotlinx/datetime/Clock {
+	public static final field Companion Lkotlinx/datetime/Clock$Companion;
+	public abstract fun now ()Lkotlinx/datetime/Instant;
+}
+
+public final class kotlinx/datetime/Clock$Companion {
+}
+
+public final class kotlinx/datetime/Clock$System : kotlinx/datetime/Clock {
+	public static final field INSTANCE Lkotlinx/datetime/Clock$System;
+	public fun now ()Lkotlinx/datetime/Instant;
+}
+
+public final class kotlinx/datetime/ClockKt {
+	public static final fun asTimeSource (Lkotlinx/datetime/Clock;)Lkotlin/time/TimeSource$WithComparableMarks;
+	public static final fun todayAt (Lkotlinx/datetime/Clock;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/LocalDate;
+	public static final fun todayIn (Lkotlinx/datetime/Clock;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/LocalDate;
+}
+
+public final class kotlinx/datetime/ConvertersKt {
+	public static final fun toJavaInstant (Lkotlinx/datetime/Instant;)Ljava/time/Instant;
+	public static final fun toJavaLocalDate (Lkotlinx/datetime/LocalDate;)Ljava/time/LocalDate;
+	public static final fun toJavaLocalDateTime (Lkotlinx/datetime/LocalDateTime;)Ljava/time/LocalDateTime;
+	public static final fun toJavaLocalTime (Lkotlinx/datetime/LocalTime;)Ljava/time/LocalTime;
+	public static final fun toJavaPeriod (Lkotlinx/datetime/DatePeriod;)Ljava/time/Period;
+	public static final fun toJavaZoneId (Lkotlinx/datetime/TimeZone;)Ljava/time/ZoneId;
+	public static final fun toJavaZoneOffset (Lkotlinx/datetime/FixedOffsetTimeZone;)Ljava/time/ZoneOffset;
+	public static final fun toJavaZoneOffset (Lkotlinx/datetime/UtcOffset;)Ljava/time/ZoneOffset;
+	public static final fun toKotlinDatePeriod (Ljava/time/Period;)Lkotlinx/datetime/DatePeriod;
+	public static final fun toKotlinFixedOffsetTimeZone (Ljava/time/ZoneOffset;)Lkotlinx/datetime/FixedOffsetTimeZone;
+	public static final fun toKotlinInstant (Ljava/time/Instant;)Lkotlinx/datetime/Instant;
+	public static final fun toKotlinLocalDate (Ljava/time/LocalDate;)Lkotlinx/datetime/LocalDate;
+	public static final fun toKotlinLocalDateTime (Ljava/time/LocalDateTime;)Lkotlinx/datetime/LocalDateTime;
+	public static final fun toKotlinLocalTime (Ljava/time/LocalTime;)Lkotlinx/datetime/LocalTime;
+	public static final fun toKotlinTimeZone (Ljava/time/ZoneId;)Lkotlinx/datetime/TimeZone;
+	public static final fun toKotlinUtcOffset (Ljava/time/ZoneOffset;)Lkotlinx/datetime/UtcOffset;
+	public static final fun toKotlinZoneOffset (Ljava/time/ZoneOffset;)Lkotlinx/datetime/FixedOffsetTimeZone;
+}
+
+public final class kotlinx/datetime/DatePeriod : kotlinx/datetime/DateTimePeriod {
+	public static final field Companion Lkotlinx/datetime/DatePeriod$Companion;
+	public fun <init> (III)V
+	public synthetic fun <init> (IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getDays ()I
+	public fun getHours ()I
+	public fun getMinutes ()I
+	public fun getNanoseconds ()I
+	public fun getSeconds ()I
+}
+
+public final class kotlinx/datetime/DatePeriod$Companion {
+	public final fun parse (Ljava/lang/String;)Lkotlinx/datetime/DatePeriod;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/datetime/DateTimeArithmeticException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract class kotlinx/datetime/DateTimePeriod {
+	public static final field Companion Lkotlinx/datetime/DateTimePeriod$Companion;
+	public fun equals (Ljava/lang/Object;)Z
+	public abstract fun getDays ()I
+	public fun getHours ()I
+	public fun getMinutes ()I
+	public final fun getMonths ()I
+	public fun getNanoseconds ()I
+	public fun getSeconds ()I
+	public final fun getYears ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class kotlinx/datetime/DateTimePeriod$Companion {
+	public final fun parse (Ljava/lang/String;)Lkotlinx/datetime/DateTimePeriod;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/datetime/DateTimePeriodKt {
+	public static final fun DateTimePeriod (IIIIIIJ)Lkotlinx/datetime/DateTimePeriod;
+	public static synthetic fun DateTimePeriod$default (IIIIIIJILjava/lang/Object;)Lkotlinx/datetime/DateTimePeriod;
+	public static final fun plus (Lkotlinx/datetime/DatePeriod;Lkotlinx/datetime/DatePeriod;)Lkotlinx/datetime/DatePeriod;
+	public static final fun plus (Lkotlinx/datetime/DateTimePeriod;Lkotlinx/datetime/DateTimePeriod;)Lkotlinx/datetime/DateTimePeriod;
+	public static final fun toDatePeriod (Ljava/lang/String;)Lkotlinx/datetime/DatePeriod;
+	public static final fun toDateTimePeriod (Ljava/lang/String;)Lkotlinx/datetime/DateTimePeriod;
+	public static final fun toDateTimePeriod-LRDsOJo (J)Lkotlinx/datetime/DateTimePeriod;
+}
+
+public abstract class kotlinx/datetime/DateTimeUnit {
+	public static final field Companion Lkotlinx/datetime/DateTimeUnit$Companion;
+	protected final fun formatToString (ILjava/lang/String;)Ljava/lang/String;
+	protected final fun formatToString (JLjava/lang/String;)Ljava/lang/String;
+	public abstract fun times (I)Lkotlinx/datetime/DateTimeUnit;
+}
+
+public final class kotlinx/datetime/DateTimeUnit$Companion {
+	public final fun getCENTURY ()Lkotlinx/datetime/DateTimeUnit$MonthBased;
+	public final fun getDAY ()Lkotlinx/datetime/DateTimeUnit$DayBased;
+	public final fun getHOUR ()Lkotlinx/datetime/DateTimeUnit$TimeBased;
+	public final fun getMICROSECOND ()Lkotlinx/datetime/DateTimeUnit$TimeBased;
+	public final fun getMILLISECOND ()Lkotlinx/datetime/DateTimeUnit$TimeBased;
+	public final fun getMINUTE ()Lkotlinx/datetime/DateTimeUnit$TimeBased;
+	public final fun getMONTH ()Lkotlinx/datetime/DateTimeUnit$MonthBased;
+	public final fun getNANOSECOND ()Lkotlinx/datetime/DateTimeUnit$TimeBased;
+	public final fun getQUARTER ()Lkotlinx/datetime/DateTimeUnit$MonthBased;
+	public final fun getSECOND ()Lkotlinx/datetime/DateTimeUnit$TimeBased;
+	public final fun getWEEK ()Lkotlinx/datetime/DateTimeUnit$DayBased;
+	public final fun getYEAR ()Lkotlinx/datetime/DateTimeUnit$MonthBased;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class kotlinx/datetime/DateTimeUnit$DateBased : kotlinx/datetime/DateTimeUnit {
+	public static final field Companion Lkotlinx/datetime/DateTimeUnit$DateBased$Companion;
+}
+
+public final class kotlinx/datetime/DateTimeUnit$DateBased$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/datetime/DateTimeUnit$DayBased : kotlinx/datetime/DateTimeUnit$DateBased {
+	public static final field Companion Lkotlinx/datetime/DateTimeUnit$DayBased$Companion;
+	public fun <init> (I)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDays ()I
+	public fun hashCode ()I
+	public fun times (I)Lkotlinx/datetime/DateTimeUnit$DayBased;
+	public synthetic fun times (I)Lkotlinx/datetime/DateTimeUnit;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class kotlinx/datetime/DateTimeUnit$DayBased$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/datetime/DateTimeUnit$MonthBased : kotlinx/datetime/DateTimeUnit$DateBased {
+	public static final field Companion Lkotlinx/datetime/DateTimeUnit$MonthBased$Companion;
+	public fun <init> (I)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMonths ()I
+	public fun hashCode ()I
+	public fun times (I)Lkotlinx/datetime/DateTimeUnit$MonthBased;
+	public synthetic fun times (I)Lkotlinx/datetime/DateTimeUnit;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class kotlinx/datetime/DateTimeUnit$MonthBased$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/datetime/DateTimeUnit$TimeBased : kotlinx/datetime/DateTimeUnit {
+	public static final field Companion Lkotlinx/datetime/DateTimeUnit$TimeBased$Companion;
+	public fun <init> (J)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration-UwyO8pc ()J
+	public final fun getNanoseconds ()J
+	public fun hashCode ()I
+	public fun times (I)Lkotlinx/datetime/DateTimeUnit$TimeBased;
+	public synthetic fun times (I)Lkotlinx/datetime/DateTimeUnit;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class kotlinx/datetime/DateTimeUnit$TimeBased$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/datetime/DayOfWeekKt {
+	public static final fun DayOfWeek (I)Ljava/time/DayOfWeek;
+	public static final fun getIsoDayNumber (Ljava/time/DayOfWeek;)I
+}
+
+public final class kotlinx/datetime/FixedOffsetTimeZone : kotlinx/datetime/TimeZone {
+	public static final field Companion Lkotlinx/datetime/FixedOffsetTimeZone$Companion;
+	public fun <init> (Lkotlinx/datetime/UtcOffset;)V
+	public final fun getOffset ()Lkotlinx/datetime/UtcOffset;
+	public final fun getTotalSeconds ()I
+}
+
+public final class kotlinx/datetime/FixedOffsetTimeZone$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/datetime/IllegalTimeZoneException : java/lang/IllegalArgumentException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public final class kotlinx/datetime/Instant : java/lang/Comparable {
+	public static final field Companion Lkotlinx/datetime/Instant$Companion;
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo (Lkotlinx/datetime/Instant;)I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEpochSeconds ()J
+	public final fun getNanosecondsOfSecond ()I
+	public fun hashCode ()I
+	public final fun minus-5sfh64U (Lkotlinx/datetime/Instant;)J
+	public final fun minus-LRDsOJo (J)Lkotlinx/datetime/Instant;
+	public final fun plus-LRDsOJo (J)Lkotlinx/datetime/Instant;
+	public final fun toEpochMilliseconds ()J
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class kotlinx/datetime/Instant$Companion {
+	public final fun fromEpochMilliseconds (J)Lkotlinx/datetime/Instant;
+	public final fun fromEpochSeconds (JI)Lkotlinx/datetime/Instant;
+	public final fun fromEpochSeconds (JJ)Lkotlinx/datetime/Instant;
+	public static synthetic fun fromEpochSeconds$default (Lkotlinx/datetime/Instant$Companion;JJILjava/lang/Object;)Lkotlinx/datetime/Instant;
+	public final fun getDISTANT_FUTURE ()Lkotlinx/datetime/Instant;
+	public final fun getDISTANT_PAST ()Lkotlinx/datetime/Instant;
+	public final fun now ()Lkotlinx/datetime/Instant;
+	public final fun parse (Ljava/lang/String;)Lkotlinx/datetime/Instant;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/datetime/InstantJvmKt {
+	public static final fun minus (Lkotlinx/datetime/Instant;ILkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final fun periodUntil (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/DateTimePeriod;
+	public static final fun plus (Lkotlinx/datetime/Instant;ILkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final fun plus (Lkotlinx/datetime/Instant;JLkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlinx/datetime/Instant;
+	public static final fun plus (Lkotlinx/datetime/Instant;JLkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final fun plus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimePeriod;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final fun plus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final fun until (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)J
+}
+
+public final class kotlinx/datetime/InstantKt {
+	public static final fun daysUntil (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/TimeZone;)I
+	public static final fun isDistantFuture (Lkotlinx/datetime/Instant;)Z
+	public static final fun isDistantPast (Lkotlinx/datetime/Instant;)Z
+	public static final fun minus (Lkotlinx/datetime/Instant;ILkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlinx/datetime/Instant;
+	public static final fun minus (Lkotlinx/datetime/Instant;JLkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlinx/datetime/Instant;
+	public static final fun minus (Lkotlinx/datetime/Instant;JLkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final fun minus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimePeriod;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final fun minus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlinx/datetime/Instant;
+	public static final fun minus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final fun minus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit$TimeBased;)J
+	public static final fun minus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)J
+	public static final fun minus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/DateTimePeriod;
+	public static final fun monthsUntil (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/TimeZone;)I
+	public static final fun plus (Lkotlinx/datetime/Instant;ILkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlinx/datetime/Instant;
+	public static final fun plus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlinx/datetime/Instant;
+	public static final fun toInstant (Ljava/lang/String;)Lkotlinx/datetime/Instant;
+	public static final fun until (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit$TimeBased;)J
+	public static final fun yearsUntil (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/TimeZone;)I
+}
+
+public final class kotlinx/datetime/LocalDate : java/lang/Comparable {
+	public static final field Companion Lkotlinx/datetime/LocalDate$Companion;
+	public fun <init> (III)V
+	public fun <init> (ILjava/time/Month;I)V
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo (Lkotlinx/datetime/LocalDate;)I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDayOfMonth ()I
+	public final fun getDayOfWeek ()Ljava/time/DayOfWeek;
+	public final fun getDayOfYear ()I
+	public final fun getMonth ()Ljava/time/Month;
+	public final fun getMonthNumber ()I
+	public final fun getYear ()I
+	public fun hashCode ()I
+	public final fun toEpochDays ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class kotlinx/datetime/LocalDate$Companion {
+	public final fun fromEpochDays (I)Lkotlinx/datetime/LocalDate;
+	public final fun parse (Ljava/lang/String;)Lkotlinx/datetime/LocalDate;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/datetime/LocalDateJvmKt {
+	public static final fun daysUntil (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)I
+	public static final fun minus (Lkotlinx/datetime/LocalDate;ILkotlinx/datetime/DateTimeUnit$DateBased;)Lkotlinx/datetime/LocalDate;
+	public static final fun monthsUntil (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)I
+	public static final fun periodUntil (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)Lkotlinx/datetime/DatePeriod;
+	public static final fun plus (Lkotlinx/datetime/LocalDate;ILkotlinx/datetime/DateTimeUnit$DateBased;)Lkotlinx/datetime/LocalDate;
+	public static final fun plus (Lkotlinx/datetime/LocalDate;JLkotlinx/datetime/DateTimeUnit$DateBased;)Lkotlinx/datetime/LocalDate;
+	public static final fun plus (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/DatePeriod;)Lkotlinx/datetime/LocalDate;
+	public static final fun plus (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/DateTimeUnit$DateBased;)Lkotlinx/datetime/LocalDate;
+	public static final fun until (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/DateTimeUnit$DateBased;)I
+	public static final fun yearsUntil (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)I
+}
+
+public final class kotlinx/datetime/LocalDateKt {
+	public static final fun atTime (Lkotlinx/datetime/LocalDate;IIII)Lkotlinx/datetime/LocalDateTime;
+	public static final fun atTime (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalTime;)Lkotlinx/datetime/LocalDateTime;
+	public static synthetic fun atTime$default (Lkotlinx/datetime/LocalDate;IIIIILjava/lang/Object;)Lkotlinx/datetime/LocalDateTime;
+	public static final fun minus (Lkotlinx/datetime/LocalDate;JLkotlinx/datetime/DateTimeUnit$DateBased;)Lkotlinx/datetime/LocalDate;
+	public static final fun minus (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/DatePeriod;)Lkotlinx/datetime/LocalDate;
+	public static final fun minus (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/DateTimeUnit$DateBased;)Lkotlinx/datetime/LocalDate;
+	public static final fun minus (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)Lkotlinx/datetime/DatePeriod;
+	public static final fun toLocalDate (Ljava/lang/String;)Lkotlinx/datetime/LocalDate;
+}
+
+public final class kotlinx/datetime/LocalDateTime : java/lang/Comparable {
+	public static final field Companion Lkotlinx/datetime/LocalDateTime$Companion;
+	public fun <init> (IIIIIII)V
+	public synthetic fun <init> (IIIIIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/time/Month;IIIII)V
+	public synthetic fun <init> (ILjava/time/Month;IIIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalTime;)V
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo (Lkotlinx/datetime/LocalDateTime;)I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDate ()Lkotlinx/datetime/LocalDate;
+	public final fun getDayOfMonth ()I
+	public final fun getDayOfWeek ()Ljava/time/DayOfWeek;
+	public final fun getDayOfYear ()I
+	public final fun getHour ()I
+	public final fun getMinute ()I
+	public final fun getMonth ()Ljava/time/Month;
+	public final fun getMonthNumber ()I
+	public final fun getNanosecond ()I
+	public final fun getSecond ()I
+	public final fun getTime ()Lkotlinx/datetime/LocalTime;
+	public final fun getYear ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class kotlinx/datetime/LocalDateTime$Companion {
+	public final fun parse (Ljava/lang/String;)Lkotlinx/datetime/LocalDateTime;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/datetime/LocalDateTimeKt {
+	public static final fun toLocalDateTime (Ljava/lang/String;)Lkotlinx/datetime/LocalDateTime;
+}
+
+public final class kotlinx/datetime/LocalTime : java/lang/Comparable {
+	public static final field Companion Lkotlinx/datetime/LocalTime$Companion;
+	public fun <init> (IIII)V
+	public synthetic fun <init> (IIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo (Lkotlinx/datetime/LocalTime;)I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHour ()I
+	public final fun getMinute ()I
+	public final fun getNanosecond ()I
+	public final fun getSecond ()I
+	public fun hashCode ()I
+	public final fun toMillisecondOfDay ()I
+	public final fun toNanosecondOfDay ()J
+	public final fun toSecondOfDay ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class kotlinx/datetime/LocalTime$Companion {
+	public final fun fromMillisecondOfDay (I)Lkotlinx/datetime/LocalTime;
+	public final fun fromNanosecondOfDay (J)Lkotlinx/datetime/LocalTime;
+	public final fun fromSecondOfDay (I)Lkotlinx/datetime/LocalTime;
+	public final fun parse (Ljava/lang/String;)Lkotlinx/datetime/LocalTime;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/datetime/LocalTimeKt {
+	public static final fun atDate (Lkotlinx/datetime/LocalTime;III)Lkotlinx/datetime/LocalDateTime;
+	public static final fun atDate (Lkotlinx/datetime/LocalTime;ILjava/time/Month;I)Lkotlinx/datetime/LocalDateTime;
+	public static final fun atDate (Lkotlinx/datetime/LocalTime;Lkotlinx/datetime/LocalDate;)Lkotlinx/datetime/LocalDateTime;
+	public static synthetic fun atDate$default (Lkotlinx/datetime/LocalTime;IIIILjava/lang/Object;)Lkotlinx/datetime/LocalDateTime;
+	public static synthetic fun atDate$default (Lkotlinx/datetime/LocalTime;ILjava/time/Month;IILjava/lang/Object;)Lkotlinx/datetime/LocalDateTime;
+	public static final fun toLocalTime (Ljava/lang/String;)Lkotlinx/datetime/LocalTime;
+}
+
+public final class kotlinx/datetime/MonthKt {
+	public static final fun Month (I)Ljava/time/Month;
+	public static final fun getNumber (Ljava/time/Month;)I
+}
+
+public class kotlinx/datetime/TimeZone {
+	public static final field Companion Lkotlinx/datetime/TimeZone$Companion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toInstant (Lkotlinx/datetime/LocalDateTime;)Lkotlinx/datetime/Instant;
+	public final fun toLocalDateTime (Lkotlinx/datetime/Instant;)Lkotlinx/datetime/LocalDateTime;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class kotlinx/datetime/TimeZone$Companion {
+	public final fun currentSystemDefault ()Lkotlinx/datetime/TimeZone;
+	public final fun getAvailableZoneIds ()Ljava/util/Set;
+	public final fun getUTC ()Lkotlinx/datetime/FixedOffsetTimeZone;
+	public final fun of (Ljava/lang/String;)Lkotlinx/datetime/TimeZone;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/datetime/TimeZoneKt {
+	public static final fun atStartOfDayIn (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final fun offsetAt (Lkotlinx/datetime/TimeZone;Lkotlinx/datetime/Instant;)Lkotlinx/datetime/UtcOffset;
+	public static final fun offsetIn (Lkotlinx/datetime/Instant;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/UtcOffset;
+	public static final fun toInstant (Lkotlinx/datetime/LocalDateTime;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final fun toInstant (Lkotlinx/datetime/LocalDateTime;Lkotlinx/datetime/UtcOffset;)Lkotlinx/datetime/Instant;
+	public static final fun toLocalDateTime (Lkotlinx/datetime/Instant;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/LocalDateTime;
+}
+
+public final class kotlinx/datetime/UtcOffset {
+	public static final field Companion Lkotlinx/datetime/UtcOffset$Companion;
+	public fun <init> (Ljava/time/ZoneOffset;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTotalSeconds ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class kotlinx/datetime/UtcOffset$Companion {
+	public final fun getZERO ()Lkotlinx/datetime/UtcOffset;
+	public final fun parse (Ljava/lang/String;)Lkotlinx/datetime/UtcOffset;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class kotlinx/datetime/UtcOffsetJvmKt {
+	public static final fun UtcOffset (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)Lkotlinx/datetime/UtcOffset;
+	public static synthetic fun UtcOffset$default (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/datetime/UtcOffset;
+}
+
+public final class kotlinx/datetime/UtcOffsetKt {
+	public static final fun UtcOffset ()Lkotlinx/datetime/UtcOffset;
+	public static final fun asTimeZone (Lkotlinx/datetime/UtcOffset;)Lkotlinx/datetime/FixedOffsetTimeZone;
+}
+
+public final class kotlinx/datetime/serializers/DateBasedDateTimeUnitSerializer : kotlinx/serialization/internal/AbstractPolymorphicSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/DateBasedDateTimeUnitSerializer;
+	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/String;)Lkotlinx/serialization/DeserializationStrategy;
+	public synthetic fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)Lkotlinx/serialization/SerializationStrategy;
+	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/DateTimeUnit$DateBased;)Lkotlinx/serialization/SerializationStrategy;
+	public fun getBaseClass ()Lkotlin/reflect/KClass;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+}
+
+public final class kotlinx/datetime/serializers/DatePeriodComponentSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/DatePeriodComponentSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/DatePeriod;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/DatePeriod;)V
+}
+
+public final class kotlinx/datetime/serializers/DatePeriodIso8601Serializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/DatePeriodIso8601Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/DatePeriod;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/DatePeriod;)V
+}
+
+public final class kotlinx/datetime/serializers/DateTimePeriodComponentSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/DateTimePeriodComponentSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/DateTimePeriod;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/DateTimePeriod;)V
+}
+
+public final class kotlinx/datetime/serializers/DateTimePeriodIso8601Serializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/DateTimePeriodIso8601Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/DateTimePeriod;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/DateTimePeriod;)V
+}
+
+public final class kotlinx/datetime/serializers/DateTimeUnitSerializer : kotlinx/serialization/internal/AbstractPolymorphicSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/DateTimeUnitSerializer;
+	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/CompositeDecoder;Ljava/lang/String;)Lkotlinx/serialization/DeserializationStrategy;
+	public synthetic fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)Lkotlinx/serialization/SerializationStrategy;
+	public fun findPolymorphicSerializerOrNull (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/DateTimeUnit;)Lkotlinx/serialization/SerializationStrategy;
+	public fun getBaseClass ()Lkotlin/reflect/KClass;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+}
+
+public final class kotlinx/datetime/serializers/DayBasedDateTimeUnitSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/DayBasedDateTimeUnitSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/DateTimeUnit$DayBased;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/DateTimeUnit$DayBased;)V
+}
+
+public final class kotlinx/datetime/serializers/DayOfWeekSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/DayOfWeekSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/time/DayOfWeek;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/time/DayOfWeek;)V
+}
+
+public final class kotlinx/datetime/serializers/FixedOffsetTimeZoneSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/FixedOffsetTimeZoneSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/FixedOffsetTimeZone;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/FixedOffsetTimeZone;)V
+}
+
+public final class kotlinx/datetime/serializers/InstantComponentSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/InstantComponentSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/Instant;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/Instant;)V
+}
+
+public final class kotlinx/datetime/serializers/InstantIso8601Serializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/InstantIso8601Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/Instant;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/Instant;)V
+}
+
+public final class kotlinx/datetime/serializers/LocalDateComponentSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/LocalDateComponentSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/LocalDate;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalDate;)V
+}
+
+public final class kotlinx/datetime/serializers/LocalDateIso8601Serializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/LocalDateIso8601Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/LocalDate;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalDate;)V
+}
+
+public final class kotlinx/datetime/serializers/LocalDateTimeComponentSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/LocalDateTimeComponentSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/LocalDateTime;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalDateTime;)V
+}
+
+public final class kotlinx/datetime/serializers/LocalDateTimeIso8601Serializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/LocalDateTimeIso8601Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/LocalDateTime;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalDateTime;)V
+}
+
+public final class kotlinx/datetime/serializers/LocalTimeComponentSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/LocalTimeComponentSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/LocalTime;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalTime;)V
+}
+
+public final class kotlinx/datetime/serializers/LocalTimeIso8601Serializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/LocalTimeIso8601Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/LocalTime;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalTime;)V
+}
+
+public final class kotlinx/datetime/serializers/MonthBasedDateTimeUnitSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/MonthBasedDateTimeUnitSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/DateTimeUnit$MonthBased;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/DateTimeUnit$MonthBased;)V
+}
+
+public final class kotlinx/datetime/serializers/MonthSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/MonthSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/time/Month;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/time/Month;)V
+}
+
+public final class kotlinx/datetime/serializers/TimeBasedDateTimeUnitSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/TimeBasedDateTimeUnitSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/DateTimeUnit$TimeBased;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/DateTimeUnit$TimeBased;)V
+}
+
+public final class kotlinx/datetime/serializers/TimeZoneSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/TimeZoneSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/TimeZone;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/TimeZone;)V
+}
+
+public final class kotlinx/datetime/serializers/UtcOffsetSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/UtcOffsetSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/UtcOffset;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/UtcOffset;)V
+}
+


### PR DESCRIPTION
The change is related to building datetime as a Kotlin user project.
See [KT-61621](https://youtrack.jetbrains.com/issue/KT-61621) for more details.