### PR TITLE
Enable error loglevel for partial linkage messages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,4 +27,10 @@ allprojects {
         // outputs the compiler version to logs so we can check whether the train configuration applied
         kotlinOptions.freeCompilerArgs += "-version"
     }
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile>().configureEach {
+        compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=ERROR") }
+    }
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile>().configureEach {
+        compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=ERROR") }
+    }
 }


### PR DESCRIPTION
The change is related to building datetime as a Kotlin user project.
See [QA-1099](https://youtrack.jetbrains.com/issue/QA-1099) for more details.