### PR TITLE
Ensure better ISO 8601 compliance

### DIFF
--- a/core/common/test/InstantTest.kt
+++ b/core/common/test/InstantTest.kt
@@ -268,6 +268,16 @@ class InstantTest {
     }
 
     @Test
+    fun dateTimePeriodWithGapBetweenMonthsAndDays() {
+        val zone = TimeZone.of("America/New_York")
+        // LocalDateTime(2019, 3, 10, 2, 0) is a gap.
+        // If months and days are not added atomically, the result will be adjusted.
+        val start = Instant.parse("2019-02-10T02:00:00-05:00")
+        val end = start.plus(DateTimePeriod(months = 1, days = 1), zone)
+        assertEquals(Instant.parse("2019-03-11T02:00:00-04:00"), end)
+    }
+
+    @Test
     fun diffInvariant() {
         repeat(STRESS_TEST_ITERATIONS) {
             val millis1 = Random.nextLong(2_000_000_000_000L)

--- a/core/commonJs/src/Instant.kt
+++ b/core/commonJs/src/Instant.kt
@@ -118,23 +118,6 @@ public actual class Instant internal constructor(internal val value: jtInstant) 
     }
 }
 
-
-public actual fun Instant.plus(period: DateTimePeriod, timeZone: TimeZone): Instant = try {
-    val thisZdt = jsTry { this.value.atZone(timeZone.zoneId) }
-    with(period) {
-        thisZdt
-                .run { if (totalMonths != 0) jsTry { plusMonths(totalMonths) } else this }
-                .run { if (days != 0) jsTry { plusDays(days) } else this }
-                .run { if (hours != 0) jsTry { plusHours(hours) } else this }
-                .run { if (minutes != 0) jsTry { plusMinutes(minutes) } else this }
-                .run { if (seconds != 0) jsTry { plusSeconds(seconds) } else this }
-                .run { if (nanoseconds != 0) jsTry { plusNanos(nanoseconds.toDouble()) } else this }
-    }.toInstant().let(::Instant)
-}    catch (e: Throwable) {
-    if (e.isJodaDateTimeException()) throw DateTimeArithmeticException(e)
-    throw e
-}
-
 private fun Instant.atZone(zone: TimeZone): jtZonedDateTime = jsTry { value.atZone(zone.zoneId) }
 private fun jtInstant.checkZone(zone: TimeZone): jtInstant = apply { jsTry { atZone(zone.zoneId) } }
 
@@ -192,19 +175,6 @@ public actual fun Instant.plus(value: Long, unit: DateTimeUnit.TimeBased): Insta
         }
         if (value > 0) Instant.MAX else Instant.MIN
     }
-
-public actual fun Instant.periodUntil(other: Instant, timeZone: TimeZone): DateTimePeriod = try {
-    var thisZdt = jsTry { this.value.atZone(timeZone.zoneId) }
-    val otherZdt = jsTry { other.value.atZone(timeZone.zoneId) }
-
-    val months = thisZdt.until(otherZdt, jtChronoUnit.MONTHS); thisZdt = jsTry { thisZdt.plusMonths(months) }
-    val days = thisZdt.until(otherZdt, jtChronoUnit.DAYS); thisZdt = jsTry { thisZdt.plusDays(days) }
-    val nanoseconds = thisZdt.until(otherZdt, jtChronoUnit.NANOS)
-
-    buildDateTimePeriod(months.toInt(), days.toInt(), nanoseconds.toLong())
-} catch (e: Throwable) {
-    if (e.isJodaDateTimeException()) throw DateTimeArithmeticException(e) else throw e
-}
 
 public actual fun Instant.until(other: Instant, unit: DateTimeUnit, timeZone: TimeZone): Long = try {
     val thisZdt = this.atZone(timeZone)


### PR DESCRIPTION
ISO 8601 defines the period of one month as a fixed number of calendar days, specified by the calendar.

Before this change, we treated a month as a separate time scale unit during `DatePeriod` arithmetics, namely, we resolved the `LocalDateTime` on which we did arithmetics internally after adding the months but before adding the days.

This change makes it so that adding months and days is done as a single change, only consulting the calendar, and the time zone is only used once all calendar-based operations are performed.

The code that calculates the `DateTimePeriod` between two `Instant` values is changed symmetrically.