### PR TITLE
Restore the broken bit of ABI compatibility for Native, JS, and Wasm

### DIFF
--- a/core/commonJs/src/Instant.kt
+++ b/core/commonJs/src/Instant.kt
@@ -90,6 +90,9 @@ public actual class Instant internal constructor(internal val value: jtInstant) 
                 }
             }
 
+        @Deprecated("This overload is only kept for binary compatibility", level = DeprecationLevel.HIDDEN)
+        public fun parse(isoString: String): Instant = parse(input = isoString)
+
         /** A workaround for the string representations of Instant that have an offset of the form
          * "+XX" not being recognized by [jtOffsetDateTime.parse], while "+XX:XX" work fine. */
         private fun fixOffsetRepresentation(isoString: String): String {

--- a/core/commonJs/src/LocalDate.kt
+++ b/core/commonJs/src/LocalDate.kt
@@ -29,6 +29,9 @@ public actual class LocalDate internal constructor(internal val value: jtLocalDa
             format.parse(input)
         }
 
+        @Deprecated("This overload is only kept for binary compatibility", level = DeprecationLevel.HIDDEN)
+        public fun parse(isoString: String): LocalDate = parse(input = isoString)
+
         internal actual val MIN: LocalDate = LocalDate(jtLocalDate.MIN)
         internal actual val MAX: LocalDate = LocalDate(jtLocalDate.MAX)
 

--- a/core/commonJs/src/LocalDateTime.kt
+++ b/core/commonJs/src/LocalDateTime.kt
@@ -66,6 +66,9 @@ public actual class LocalDateTime internal constructor(internal val value: jtLoc
                 format.parse(input)
             }
 
+        @Deprecated("This overload is only kept for binary compatibility", level = DeprecationLevel.HIDDEN)
+        public fun parse(isoString: String): LocalDateTime = parse(input = isoString)
+
         internal actual val MIN: LocalDateTime = LocalDateTime(jtLocalDateTime.MIN)
         internal actual val MAX: LocalDateTime = LocalDateTime(jtLocalDateTime.MAX)
 

--- a/core/commonJs/src/LocalTime.kt
+++ b/core/commonJs/src/LocalTime.kt
@@ -56,6 +56,9 @@ public actual class LocalTime internal constructor(internal val value: jtLocalTi
                 format.parse(input)
             }
 
+        @Deprecated("This overload is only kept for binary compatibility", level = DeprecationLevel.HIDDEN)
+        public fun parse(isoString: String): LocalTime = parse(input = isoString)
+
         public actual fun fromSecondOfDay(secondOfDay: Int): LocalTime = try {
             jsTry { jtLocalTime.ofSecondOfDay(secondOfDay, 0) }.let(::LocalTime)
         } catch (e: Throwable) {

--- a/core/commonJs/src/UtcOffset.kt
+++ b/core/commonJs/src/UtcOffset.kt
@@ -32,6 +32,9 @@ public actual class UtcOffset internal constructor(internal val zoneOffset: jtZo
             else -> format.parse(input)
         }
 
+        @Deprecated("This overload is only kept for binary compatibility", level = DeprecationLevel.HIDDEN)
+        public fun parse(offsetString: String): UtcOffset = parse(input = offsetString)
+
         @Suppress("FunctionName")
         public actual fun Format(block: DateTimeFormatBuilder.WithUtcOffset.() -> Unit): DateTimeFormat<UtcOffset> =
             UtcOffsetFormat.build(block)

--- a/core/native/src/Instant.kt
+++ b/core/native/src/Instant.kt
@@ -143,6 +143,9 @@ public actual class Instant internal constructor(public actual val epochSeconds:
             throw DateTimeFormatException("Failed to parse an instant from '$input'", e)
         }
 
+        @Deprecated("This overload is only kept for binary compatibility", level = DeprecationLevel.HIDDEN)
+        public fun parse(isoString: String): Instant = parse(input = isoString)
+
         public actual val DISTANT_PAST: Instant = fromEpochSeconds(DISTANT_PAST_SECONDS, 999_999_999)
 
         public actual val DISTANT_FUTURE: Instant = fromEpochSeconds(DISTANT_FUTURE_SECONDS, 0)

--- a/core/native/src/LocalDate.kt
+++ b/core/native/src/LocalDate.kt
@@ -44,6 +44,9 @@ public actual class LocalDate actual constructor(public actual val year: Int, pu
     public actual companion object {
         public actual fun parse(input: CharSequence, format: DateTimeFormat<LocalDate>): LocalDate = format.parse(input)
 
+        @Deprecated("This overload is only kept for binary compatibility", level = DeprecationLevel.HIDDEN)
+        public fun parse(isoString: String): LocalDate = parse(input = isoString)
+
         // org.threeten.bp.LocalDate#toEpochDay
         public actual fun fromEpochDays(epochDays: Int): LocalDate {
             // LocalDate(-999999, 1, 1).toEpochDay(), LocalDate(999999, 12, 31).toEpochDay()

--- a/core/native/src/LocalDateTime.kt
+++ b/core/native/src/LocalDateTime.kt
@@ -20,6 +20,9 @@ public actual constructor(public actual val date: LocalDate, public actual val t
         public actual fun parse(input: CharSequence, format: DateTimeFormat<LocalDateTime>): LocalDateTime =
             format.parse(input)
 
+        @Deprecated("This overload is only kept for binary compatibility", level = DeprecationLevel.HIDDEN)
+        public fun parse(isoString: String): LocalDateTime = parse(input = isoString)
+
         internal actual val MIN: LocalDateTime = LocalDateTime(LocalDate.MIN, LocalTime.MIN)
         internal actual val MAX: LocalDateTime = LocalDateTime(LocalDate.MAX, LocalTime.MAX)
 

--- a/core/native/src/LocalTime.kt
+++ b/core/native/src/LocalTime.kt
@@ -35,6 +35,9 @@ public actual class LocalTime actual constructor(
     public actual companion object {
         public actual fun parse(input: CharSequence, format: DateTimeFormat<LocalTime>): LocalTime = format.parse(input)
 
+        @Deprecated("This overload is only kept for binary compatibility", level = DeprecationLevel.HIDDEN)
+        public fun parse(isoString: String): LocalTime = parse(input = isoString)
+
         public actual fun fromSecondOfDay(secondOfDay: Int): LocalTime =
             ofSecondOfDay(secondOfDay, 0)
 

--- a/core/native/src/UtcOffset.kt
+++ b/core/native/src/UtcOffset.kt
@@ -24,6 +24,9 @@ public actual class UtcOffset private constructor(public actual val totalSeconds
 
         public actual fun parse(input: CharSequence, format: DateTimeFormat<UtcOffset>): UtcOffset = format.parse(input)
 
+        @Deprecated("This overload is only kept for binary compatibility", level = DeprecationLevel.HIDDEN)
+        public fun parse(offsetString: String): UtcOffset = parse(input = offsetString)
+
         private fun validateTotal(totalSeconds: Int) {
             if (totalSeconds !in -18 * SECONDS_PER_HOUR .. 18 * SECONDS_PER_HOUR) {
                 throw IllegalArgumentException("Total seconds value is out of range: $totalSeconds")


### PR DESCRIPTION
Fixes #356

Here's the corresponding commit for the JVM implementation: https://github.com/Kotlin/kotlinx-datetime/commit/4e3de8f9c6ede14721ae0136afe3b68b05e8acbb