### PR TITLE
Update Dokka to 1.9.20

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ version=0.6.0-RC.2
 versionSuffix=SNAPSHOT
 
 defaultKotlinVersion=1.9.21
-dokkaVersion=1.9.10
+dokkaVersion=1.9.20
 serializationVersion=1.6.2
 benchmarksVersion=0.7.2
 


### PR DESCRIPTION
No issues comparing to Dokka 1.9.10

**Additional note:**
During testing I've found that some declarations are not rendered on kotlinlang.org, specifically `NSDate` - https://kotlinlang.org/api/kotlinx-datetime/kotlinx-datetime/kotlinx.datetime/to-n-s-date.html
rendered as `<Error class: unknown class>`

Actual:
<img width="538" alt="image" src="https://github.com/Kotlin/kotlinx-datetime/assets/50462752/f29d8e51-25a4-40d3-8b35-0a375e5a4312">

Expected (built locally on macOS):
<img width="360" alt="image" src="https://github.com/Kotlin/kotlinx-datetime/assets/50462752/6365860b-b2e3-4c87-b952-e8ee214962d3">

So most likely teamcity setup should be adapted to build dokka on macOS - not sure who should do it