### PR TITLE
Improve performance of the parser's failure path

### DIFF
--- a/core/common/src/internal/format/parser/Parser.kt
+++ b/core/common/src/internal/format/parser/Parser.kt
@@ -179,6 +179,12 @@ internal value class Parser<Output : Copyable<Output>>(
     fun match(input: CharSequence, initialContainer: Output, startIndex: Int = 0): Output {
         val errors = mutableListOf<ParseError>()
         parse(input, startIndex, initialContainer, allowDanglingInput = false, { errors.add(it) }, { _, out -> return@match out })
+        /*
+         * We do care about **all** parser errors and provide diagnostic information to make the error message approacheable
+         * for authors of non-trivial formatters with a multitude of potential parsing paths.
+         * For that, we sort errors so that the most successful parsing paths are at the top, and
+         * add them all to the parse exception message.
+         */
         errors.sortByDescending { it.position }
         // `errors` can not be empty because each parser will have (successes + failures) >= 1, and here, successes == 0
         throw ParseException(errors)

--- a/core/common/src/internal/format/parser/Parser.kt
+++ b/core/common/src/internal/format/parser/Parser.kt
@@ -48,6 +48,7 @@ internal fun <T> List<ParserStructure<T>>.concat(): ParserStructure<T> {
     } else {
         ParserStructure(operations, followedBy.map { it.append(other) })
     }
+
     fun <T> ParserStructure<T>.simplify(): ParserStructure<T> {
         val newOperations = mutableListOf<ParserOperation<T>>()
         var currentNumberSpan: MutableList<NumberConsumer<T>>? = null
@@ -122,7 +123,7 @@ internal interface Copyable<Self> {
 }
 
 @JvmInline
-internal value class Parser<Output: Copyable<Output>>(
+internal value class Parser<Output : Copyable<Output>>(
     private val commands: ParserStructure<Output>
 ) {
     /**
@@ -145,7 +146,7 @@ internal value class Parser<Output: Copyable<Output>>(
         onSuccess: (Int, Output) -> Unit
     ) {
         val parseOptions = mutableListOf(ParserState(initialContainer, commands, startIndex))
-        iterate_over_alternatives@while (true) {
+        iterate_over_alternatives@ while (true) {
             val state = parseOptions.removeLastOrNull() ?: break
             val output = state.output.copy()
             var inputPosition = state.inputPosition
@@ -180,12 +181,7 @@ internal value class Parser<Output: Copyable<Output>>(
         parse(input, startIndex, initialContainer, allowDanglingInput = false, { errors.add(it) }, { _, out -> return@match out })
         errors.sortByDescending { it.position }
         // `errors` can not be empty because each parser will have (successes + failures) >= 1, and here, successes == 0
-        ParseException(errors.first()).let {
-            for (error in errors.drop(1)) {
-                it.addSuppressed(ParseException(error))
-            }
-            throw it
-        }
+        throw ParseException(errors)
     }
 
     fun matchOrNull(input: CharSequence, initialContainer: Output, startIndex: Int = 0): Output? {
@@ -200,4 +196,18 @@ internal value class Parser<Output: Copyable<Output>>(
     )
 }
 
-internal class ParseException(error: ParseError) : Exception("Position ${error.position}: ${error.message()}")
+internal class ParseException(errors: List<ParseError>) : Exception(formatError(errors))
+
+private fun formatError(errors: List<ParseError>): String {
+    if (errors.size == 1) {
+        return "Position ${errors[0].position}: ${errors[0].message()}"
+    }
+    // 20 For average error string: "Expected X but got Y"
+    // 13 for static part "Position   :,"
+    val averageMessageLength = 20 + 13
+    return errors.joinTo(
+        StringBuilder(averageMessageLength * errors.size),
+        prefix = "Errors: ",
+        separator = ", "
+    ) { "position ${it.position}: '${it.message()}'" }.toString()
+}


### PR DESCRIPTION
* Previously, an exception was instantiated on each ParseError and the parsing failure was completely dominated by 'fillInStacktrace' method
* Now all exception messages are aggregated into a single message and only one instance of ParseException is thrown
* An improvement on the basic benchmark is ~300%

The changes are quite code-local and worth doing -- we are basically avoiding redundant work and making a vector for potential denial of service attacks much less.

Benchmark:
```kotlin
val zonedDtFormat = DateTimeComponents.Format {
    dateTime(LocalDateTime.Formats.ISO)
    offset(UtcOffset.Formats.ISO)
    char('[')
    timeZoneId()
    char(']')
}

val input = "2008-06-03T11:05:30.123456789+01:00[Mars/New_York]"

@Benchmark
fun fail(): Any? {
    try {
        return zonedDtFormat.parse(input)
    } catch (e: Throwable) {
        return e
    }
}
```

Profile before:
<img width="1900" alt="image" src="https://github.com/Kotlin/kotlinx-datetime/assets/2780116/486db145-a27d-4cb8-b58b-cc3f2f65eac7">

Profile after:
<img width="1879" alt="image" src="https://github.com/Kotlin/kotlinx-datetime/assets/2780116/2559b725-9a2a-435a-907c-1673e09bf559">
