### PR TITLE
Added coverage measurement using Kover

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("kotlinx.team.infra") version "0.4.0-dev-81"
     kotlin("multiplatform") apply false
+    id("org.jetbrains.kotlinx.kover") version "0.8.0-Beta2"
 }
 
 infra {
@@ -39,4 +40,20 @@ allprojects {
 // Drop this when NodeJs version that supports latest Wasm become stable
 tasks.withType<org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask>().configureEach {
     args.add("--ignore-engines")
+}
+
+kover {
+    reports {
+        verify {
+            rule {
+                // requirement for a minimum lines coverage of 85%
+                minBound(85)
+            }
+        }
+    }
+}
+
+dependencies {
+    kover(project(":kotlinx-datetime"))
+    kover(project(":kotlinx-datetime-serialization"))
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     kotlin("plugin.serialization")
     id("org.jetbrains.dokka")
     `maven-publish`
+    id("org.jetbrains.kotlinx.kover")
 }
 
 mavenPublicationsPom {

--- a/serialization/build.gradle.kts
+++ b/serialization/build.gradle.kts
@@ -3,6 +3,7 @@ import java.util.Locale
 plugins {
     id("kotlin-multiplatform")
     kotlin("plugin.serialization")
+    id("org.jetbrains.kotlinx.kover")
 }
 
 val mainJavaToolchainVersion: String by project


### PR DESCRIPTION
When running the `check` task, the validation rule will be checked automatically: minimum coverage 85% of lines.

If on-the-fly instrumentation affects the execution of the tests, then the Kover plugin must be reconfigured.

_**JVM-only targets are supported now**_