### PR TITLE
Month length + leap year methods

### DIFF
--- a/core/common/src/LocalDate.kt
+++ b/core/common/src/LocalDate.kt
@@ -376,5 +376,25 @@ public expect fun LocalDate.plus(value: Long, unit: DateTimeUnit.DateBased): Loc
  */
 public fun LocalDate.minus(value: Long, unit: DateTimeUnit.DateBased): LocalDate = plus(-value, unit)
 
+/**
+ * Checks if the year is a leap year, according to the ISO proleptic
+ * calendar system rules.
+ * <p>
+ * This method applies the current rules for leap years across the whole time-line.
+ * In general, a year is a leap year if it is divisible by four without
+ * remainder. However, years divisible by 100, are not leap years, with
+ * the exception of years divisible by 400 which are.
+ * <p>
+ * For example, 1904 is a leap year it is divisible by 4.
+ * 1900 was not a leap year as it is divisible by 100, however 2000 was a
+ * leap year as it is divisible by 400.
+ * <p>
+ * The calculation is proleptic - applying the same rules into the far future and far past.
+ * This is historically inaccurate, but is correct for the ISO-8601 standard.
+ *
+ * @return true if the year is leap, false otherwise
+ */
+public fun LocalDate.isLeapYear(): Boolean = ((year and 3) == 0) && ((year % 100) != 0 || (year % 400) == 0)
+
 // workaround for https://youtrack.jetbrains.com/issue/KT-65484
 internal fun getIsoDateFormat() = LocalDate.Formats.ISO

--- a/core/common/src/Month.kt
+++ b/core/common/src/Month.kt
@@ -61,5 +61,52 @@ public fun Month(number: Int): Month {
     return Month.entries[number - 1]
 }
 
+/**
+ * Gets the length of this month in days.
+ * <p>
+ * This takes a flag to determine whether to return the length for a leap year or not.
+ * <p>
+ * February has 28 days in a standard year and 29 days in a leap year.
+ * April, June, September and November have 30 days.
+ * All other months have 31 days.
+ *
+ * @param leapYear  true if the length is required for a leap year
+ * @return the length of this month in days, from 28 to 31
+ */
+public fun Month.length(leapYear: Boolean): Int = when (this) {
+    Month.FEBRUARY -> if (leapYear) 29 else 28
+    Month.APRIL, Month.JUNE, Month.SEPTEMBER, Month.NOVEMBER -> 30
+    else -> 31
+}
+
+/**
+ * Gets the minimum length of this month in days.
+ * <p>
+ * February has a minimum length of 28 days.
+ * April, June, September and November have 30 days.
+ * All other months have 31 days.
+ *
+ * @return the minimum length of this month in days, from 28 to 31
+ */
+public fun Month.minLength(): Int = when (this) {
+    Month.FEBRUARY -> 28
+    Month.APRIL, Month.JUNE, Month.SEPTEMBER, Month.NOVEMBER -> 30
+    else -> 31
+}
+
+/**
+ * Gets the maximum length of this month in days.
+ * <p>
+ * February has a maximum length of 29 days.
+ * April, June, September and November have 30 days.
+ * All other months have 31 days.
+ *
+ * @return the maximum length of this month in days, from 29 to 31
+ */
+public fun Month.maxLength(): Int = when (this) {
+    Month.FEBRUARY -> 29
+    Month.APRIL, Month.JUNE, Month.SEPTEMBER, Month.NOVEMBER -> 30
+    else -> 31
+}
 
 // companion object members vs type aliasing to java.time.Month?

--- a/core/common/test/LocalDateTest.kt
+++ b/core/common/test/LocalDateTest.kt
@@ -288,6 +288,14 @@ class LocalDateTest {
         assertEquals(0, LocalDate(1970, 1, 1).toEpochDays())
         assertEquals(-678942 - 40587, LocalDate(-1, 12, 31).toEpochDays())
     }
+
+    @Test
+    fun isLeapYear() {
+        assertEquals(true, LocalDate(1904, 1, 1).isLeapYear())
+        assertEquals(false, LocalDate(1900, 1, 1).isLeapYear())
+        assertEquals(true, LocalDate(2000, 1, 1).isLeapYear())
+    }
+
 }
 
 fun checkInvalidDate(constructor: (year: Int, month: Int, day: Int) -> LocalDate) {

--- a/core/common/test/MonthTest.kt
+++ b/core/common/test/MonthTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019-2024 JetBrains s.r.o. and contributors.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.datetime.test
+
+import kotlinx.datetime.Month
+import kotlinx.datetime.length
+import kotlinx.datetime.maxLength
+import kotlinx.datetime.minLength
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MonthTest {
+
+    @Test
+    fun length() {
+        assertEquals(31, Month.JANUARY.length(false))
+        assertEquals(31, Month.MARCH.length(false))
+        assertEquals(30, Month.APRIL.length(false))
+        assertEquals(31, Month.MAY.length(false))
+        assertEquals(30, Month.JUNE.length(false))
+        assertEquals(31, Month.JULY.length(false))
+        assertEquals(31, Month.AUGUST.length(false))
+        assertEquals(30, Month.SEPTEMBER.length(false))
+        assertEquals(31, Month.OCTOBER.length(false))
+        assertEquals(30, Month.NOVEMBER.length(false))
+        assertEquals(31, Month.DECEMBER.length(false))
+
+        assertEquals(28, Month.FEBRUARY.length(false))
+        assertEquals(29, Month.FEBRUARY.length(true))
+    }
+
+    @Test
+    fun minLength() {
+        assertEquals(31, Month.JANUARY.minLength())
+        assertEquals(28, Month.FEBRUARY.minLength())
+        assertEquals(31, Month.MARCH.minLength())
+        assertEquals(30, Month.APRIL.minLength())
+        assertEquals(31, Month.MAY.minLength())
+        assertEquals(30, Month.JUNE.minLength())
+        assertEquals(31, Month.JULY.minLength())
+        assertEquals(31, Month.AUGUST.minLength())
+        assertEquals(30, Month.SEPTEMBER.minLength())
+        assertEquals(31, Month.OCTOBER.minLength())
+        assertEquals(30, Month.NOVEMBER.minLength())
+        assertEquals(31, Month.DECEMBER.minLength())
+    }
+
+    @Test
+    fun maxLength() {
+        assertEquals(31, Month.JANUARY.maxLength())
+        assertEquals(29, Month.FEBRUARY.maxLength())
+        assertEquals(31, Month.MARCH.maxLength())
+        assertEquals(30, Month.APRIL.maxLength())
+        assertEquals(31, Month.MAY.maxLength())
+        assertEquals(30, Month.JUNE.maxLength())
+        assertEquals(31, Month.JULY.maxLength())
+        assertEquals(31, Month.AUGUST.maxLength())
+        assertEquals(30, Month.SEPTEMBER.maxLength())
+        assertEquals(31, Month.OCTOBER.maxLength())
+        assertEquals(30, Month.NOVEMBER.maxLength())
+        assertEquals(31, Month.DECEMBER.maxLength())
+    }
+
+}


### PR DESCRIPTION
I added `Month.length(leapYear: Boolean)`, `Month.minLength()`, `Month.maxLength()` and `LocalDate.isLeapYear()` to kotlinx datetime.
Those methods are available in the Java Time API (signature & docs are the same) but not here, so it makes it available for all platforms (not only jvm and android; useful for a kmm app for example)