### PR TITLE
Make ISO serializers for LocalTime/LocalDateTime more predictable

### DIFF
--- a/core/common/src/serializers/LocalDateTimeSerializers.kt
+++ b/core/common/src/serializers/LocalDateTimeSerializers.kt
@@ -27,7 +27,7 @@ public object LocalDateTimeIso8601Serializer: KSerializer<LocalDateTime> {
         LocalDateTime.parse(decoder.decodeString())
 
     override fun serialize(encoder: Encoder, value: LocalDateTime) {
-        encoder.encodeString(value.toString())
+        encoder.encodeString(LocalDateTime.Formats.ISO.format(value))
     }
 
 }

--- a/core/common/src/serializers/LocalTimeSerializers.kt
+++ b/core/common/src/serializers/LocalTimeSerializers.kt
@@ -27,7 +27,7 @@ public object LocalTimeIso8601Serializer : KSerializer<LocalTime> {
         LocalTime.parse(decoder.decodeString())
 
     override fun serialize(encoder: Encoder, value: LocalTime) {
-        encoder.encodeString(value.toString())
+        encoder.encodeString(LocalTime.Formats.ISO.format(value))
     }
 }
 

--- a/serialization/common/test/LocalDateTimeSerializationTest.kt
+++ b/serialization/common/test/LocalDateTimeSerializationTest.kt
@@ -15,11 +15,11 @@ import kotlin.test.*
 class LocalDateTimeSerializationTest {
     private fun iso8601Serialization(serializer: KSerializer<LocalDateTime>) {
         for ((localDateTime, json) in listOf(
-            Pair(LocalDateTime(2008, 7, 5, 2, 1), "\"2008-07-05T02:01\""),
+            Pair(LocalDateTime(2008, 7, 5, 2, 1), "\"2008-07-05T02:01:00\""),
             Pair(LocalDateTime(2007, 12, 31, 23, 59, 1), "\"2007-12-31T23:59:01\""),
-            Pair(LocalDateTime(999, 12, 31, 23, 59, 59, 990000000), "\"0999-12-31T23:59:59.990\""),
-            Pair(LocalDateTime(-1, 1, 2, 23, 59, 59, 999990000), "\"-0001-01-02T23:59:59.999990\""),
-            Pair(LocalDateTime(-2008, 1, 2, 23, 59, 59, 999999990), "\"-2008-01-02T23:59:59.999999990\""),
+            Pair(LocalDateTime(999, 12, 31, 23, 59, 59, 990000000), "\"0999-12-31T23:59:59.99\""),
+            Pair(LocalDateTime(-1, 1, 2, 23, 59, 59, 999990000), "\"-0001-01-02T23:59:59.99999\""),
+            Pair(LocalDateTime(-2008, 1, 2, 23, 59, 59, 999999990), "\"-2008-01-02T23:59:59.99999999\""),
         )) {
             assertEquals(json, Json.encodeToString(serializer, localDateTime))
             assertEquals(localDateTime, Json.decodeFromString(serializer, json))

--- a/serialization/common/test/LocalTimeSerializationTest.kt
+++ b/serialization/common/test/LocalTimeSerializationTest.kt
@@ -15,11 +15,11 @@ import kotlin.test.*
 class LocalTimeSerializationTest {
     private fun iso8601Serialization(serializer: KSerializer<LocalTime>) {
         for ((localTime, json) in listOf(
-            Pair(LocalTime(2, 1), "\"02:01\""),
+            Pair(LocalTime(2, 1), "\"02:01:00\""),
             Pair(LocalTime(23, 59, 1), "\"23:59:01\""),
-            Pair(LocalTime(23, 59, 59, 990000000), "\"23:59:59.990\""),
-            Pair(LocalTime(23, 59, 59, 999990000), "\"23:59:59.999990\""),
-            Pair(LocalTime(23, 59, 59, 999999990), "\"23:59:59.999999990\""),
+            Pair(LocalTime(23, 59, 59, 990000000), "\"23:59:59.99\""),
+            Pair(LocalTime(23, 59, 59, 999990000), "\"23:59:59.99999\""),
+            Pair(LocalTime(23, 59, 59, 999999990), "\"23:59:59.99999999\""),
         )) {
             assertEquals(json, Json.encodeToString(serializer, localTime))
             assertEquals(localTime, Json.decodeFromString(serializer, json))


### PR DESCRIPTION
Now, they will always include seconds and will not add trailing zeros for prettiness to the fractional part.

Fixes #351