### PR TITLE
No longer use `stat` in timezone database implementations

### DIFF
--- a/core/androidNative/src/internal/TzdbBionic.kt
+++ b/core/androidNative/src/internal/TzdbBionic.kt
@@ -26,9 +26,8 @@ internal fun TzdbBionic(): TimeZoneDatabase = TzdbBionic(buildMap<String, TzdbBi
         Path.fromString("/system/usr/share/zoneinfo/tzdata"), // immutable fallback tzdb
         Path.fromString("/apex/com.android.tzdata/etc/tz/tzdata"), // an up-to-date tzdb, may not exist
     )) {
-        if (path.check() == null) continue // the file does not exist
         // be careful to only read each file a single time and keep many references to the same ByteArray in memory.
-        val content = path.readBytes()
+        val content = path.readBytes() ?: continue // this file does not exist
         val header = BionicTzdbHeader.parse(content)
         val indexSize = header.data_offset - header.index_offset
         check(indexSize % 52 == 0) { "Invalid index size: $indexSize (must be a multiple of 52)" }

--- a/core/tzdbOnFilesystem/test/TimeZoneRulesCompleteTest.kt
+++ b/core/tzdbOnFilesystem/test/TimeZoneRulesCompleteTest.kt
@@ -16,12 +16,10 @@ class TimeZoneRulesCompleteTest {
     @OptIn(ExperimentalEncodingApi::class)
     @Test
     fun iterateOverAllTimezones() {
-        val root = Path.fromString("/usr/share/zoneinfo")
-        val tzdb = TzdbOnFilesystem(root)
+        val tzdb = TzdbOnFilesystem()
         for (id in tzdb.availableTimeZoneIds()) {
-            val file = root.resolve(Path.fromString(id))
             val rules = tzdb.rulesForId(id)
-            runUnixCommand("env LOCALE=C zdump -V $file").windowed(size = 2, step = 2).forEach { (line1, line2) ->
+            runUnixCommand("env LOCALE=C zdump -V ${tzdb.tzdbPath}/$id").windowed(size = 2, step = 2).forEach { (line1, line2) ->
                 val beforeTransition = parseZdumpLine(line1)
                 val afterTransition = parseZdumpLine(line2)
                 try {
@@ -51,7 +49,7 @@ class TimeZoneRulesCompleteTest {
                 } catch (e: Throwable) {
                     println(beforeTransition)
                     println(afterTransition)
-                    println(Base64.encode(file.readBytes()))
+                    println(Base64.encode(Path.fromString("${tzdb.tzdbPath}/$id").readBytes()!!))
                     throw e
                 }
             }


### PR DESCRIPTION
<https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api> states that Apple will require the apps to declare all usages of `stat`, as it can be used to check the file timestamps.