### PR TITLE
Attempt working around IDEA's issues with sample display

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -175,16 +175,25 @@ kotlin {
         commonMain {
             dependencies {
                 compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
+                // For the `@Test` annotation on samples
+                compileOnly("org.jetbrains.kotlin:kotlin-test")
             }
+            // This is part of the main source set so that IDEA knows where to look for them for the library users
+            kotlin.srcDir("common/samples")
         }
 
         commonTest {
             dependencies {
                 api("org.jetbrains.kotlin:kotlin-test")
             }
+            kotlin.srcDir("common/samples")
         }
 
         val jvmMain by getting {
+            dependencies {
+                // For the `@Test` annotation on samples
+                compileOnly("org.jetbrains.kotlin:kotlin-test-junit")
+            }
         }
 
         val jvmTest by getting {
@@ -396,7 +405,6 @@ val downloadWindowsZonesMapping by tasks.registering {
 
 tasks.withType<AbstractDokkaLeafTask>().configureEach {
     pluginsMapConfiguration.set(mapOf("org.jetbrains.dokka.base.DokkaBase" to """{ "templatesDir" : "${projectDir.toString().replace('\\', '/')}/dokka-templates" }"""))
-
     failOnWarning.set(true)
     dokkaSourceSets.configureEach {
         kotlin.sourceSets.commonTest.get().kotlin.srcDirs.forEach { samples.from(it) }
@@ -430,4 +438,16 @@ tasks.configureEach {
 with(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin.apply(rootProject)) {
     nodeVersion = "21.0.0-v8-canary202309167e82ab1fa2"
     nodeDownloadBaseUrl = "https://nodejs.org/download/v8-canary"
+}
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes(
+                    "kotlinx.datetime.test.samples.*",
+                )
+            }
+        }
+    }
 }

--- a/core/common/samples/ClockSamples.kt
+++ b/core/common/samples/ClockSamples.kt
@@ -8,7 +8,7 @@ package kotlinx.datetime.test.samples
 import kotlinx.datetime.*
 import kotlin.test.*
 
-class ClockSamples {
+@PublishedApi internal class ClockSamples {
     @Test
     fun system() {
         // Getting the current date and time

--- a/core/common/samples/DateTimePeriodSamples.kt
+++ b/core/common/samples/DateTimePeriodSamples.kt
@@ -10,7 +10,7 @@ import kotlin.test.*
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 
-class DateTimePeriodSamples {
+@PublishedApi internal class DateTimePeriodSamples {
 
     @Test
     fun construction() {
@@ -109,7 +109,7 @@ class DateTimePeriodSamples {
     }
 }
 
-class DatePeriodSamples {
+@PublishedApi internal class DatePeriodSamples {
 
     @Test
     fun simpleParsingAndFormatting() {

--- a/core/common/samples/DateTimeUnitSamples.kt
+++ b/core/common/samples/DateTimeUnitSamples.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.*
 import kotlin.test.*
 import kotlin.time.Duration.Companion.hours
 
-class DateTimeUnitSamples {
+@PublishedApi internal class DateTimeUnitSamples {
     @Test
     fun construction() {
         // Constructing various measurement units

--- a/core/common/samples/DayOfWeekSamples.kt
+++ b/core/common/samples/DayOfWeekSamples.kt
@@ -8,7 +8,7 @@ package kotlinx.datetime.test.samples
 import kotlinx.datetime.*
 import kotlin.test.*
 
-class DayOfWeekSamples {
+@PublishedApi internal class DayOfWeekSamples {
 
     @Test
     fun usage() {

--- a/core/common/samples/InstantSamples.kt
+++ b/core/common/samples/InstantSamples.kt
@@ -11,7 +11,7 @@ import kotlin.random.*
 import kotlin.test.*
 import kotlin.time.Duration.Companion.hours
 
-class InstantSamples {
+@PublishedApi internal class InstantSamples {
 
     @Test
     fun epochSeconds() {

--- a/core/common/samples/LocalDateSamples.kt
+++ b/core/common/samples/LocalDateSamples.kt
@@ -10,7 +10,7 @@ import kotlinx.datetime.format.*
 import kotlin.random.*
 import kotlin.test.*
 
-class LocalDateSamples {
+@PublishedApi internal class LocalDateSamples {
 
     @Test
     fun simpleParsingAndFormatting() {

--- a/core/common/samples/LocalDateTimeSamples.kt
+++ b/core/common/samples/LocalDateTimeSamples.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.*
 import kotlinx.datetime.format.*
 import kotlin.test.*
 
-class LocalDateTimeSamples {
+@PublishedApi internal class LocalDateTimeSamples {
 
     @Test
     fun alternativeConstruction() {

--- a/core/common/samples/LocalTimeSamples.kt
+++ b/core/common/samples/LocalTimeSamples.kt
@@ -10,7 +10,7 @@ import kotlinx.datetime.format.*
 import kotlin.random.*
 import kotlin.test.*
 
-class LocalTimeSamples {
+@PublishedApi internal class LocalTimeSamples {
 
     @Test
     fun construction() {

--- a/core/common/samples/MonthSamples.kt
+++ b/core/common/samples/MonthSamples.kt
@@ -8,7 +8,7 @@ package kotlinx.datetime.test.samples
 import kotlinx.datetime.*
 import kotlin.test.*
 
-class MonthSamples {
+@PublishedApi internal class MonthSamples {
 
     @Test
     fun usage() {

--- a/core/common/samples/TimeZoneSamples.kt
+++ b/core/common/samples/TimeZoneSamples.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.*
 import kotlinx.datetime.format.*
 import kotlin.test.*
 
-class TimeZoneSamples {
+@PublishedApi internal class TimeZoneSamples {
 
     @Test
     fun usage() {

--- a/core/common/samples/UtcOffsetSamples.kt
+++ b/core/common/samples/UtcOffsetSamples.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.*
 import kotlinx.datetime.format.*
 import kotlin.test.*
 
-class UtcOffsetSamples {
+@PublishedApi internal class UtcOffsetSamples {
 
     @Test
     fun construction() {

--- a/core/common/samples/format/DateTimeComponentsFormatSamples.kt
+++ b/core/common/samples/format/DateTimeComponentsFormatSamples.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.*
 import kotlinx.datetime.format.*
 import kotlin.test.*
 
-class DateTimeComponentsFormatSamples {
+@PublishedApi internal class DateTimeComponentsFormatSamples {
     @Test
     fun timeZoneId() {
         // Defining a custom format that includes a time zone ID

--- a/core/common/samples/format/DateTimeComponentsSamples.kt
+++ b/core/common/samples/format/DateTimeComponentsSamples.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.*
 import kotlinx.datetime.format.*
 import kotlin.test.*
 
-class DateTimeComponentsSamples {
+@PublishedApi internal class DateTimeComponentsSamples {
 
     @Test
     fun parsingComplexInput() {

--- a/core/common/samples/format/DateTimeFormatBuilderSamples.kt
+++ b/core/common/samples/format/DateTimeFormatBuilderSamples.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.*
 import kotlinx.datetime.format.*
 import kotlin.test.*
 
-class DateTimeFormatBuilderSamples {
+@PublishedApi internal class DateTimeFormatBuilderSamples {
 
     @Test
     fun chars() {

--- a/core/common/samples/format/DateTimeFormatSamples.kt
+++ b/core/common/samples/format/DateTimeFormatSamples.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.*
 import kotlinx.datetime.format.*
 import kotlin.test.*
 
-class DateTimeFormatSamples {
+@PublishedApi internal class DateTimeFormatSamples {
 
     @Test
     fun format() {

--- a/core/common/samples/format/LocalDateFormatSamples.kt
+++ b/core/common/samples/format/LocalDateFormatSamples.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.*
 import kotlinx.datetime.format.*
 import kotlin.test.*
 
-class LocalDateFormatSamples {
+@PublishedApi internal class LocalDateFormatSamples {
 
     @Test
     fun year() {

--- a/core/common/samples/format/LocalDateTimeFormatSamples.kt
+++ b/core/common/samples/format/LocalDateTimeFormatSamples.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.*
 import kotlinx.datetime.format.*
 import kotlin.test.*
 
-class LocalDateTimeFormatSamples {
+@PublishedApi internal class LocalDateTimeFormatSamples {
     @Test
     fun dateTime() {
         // Using a predefined LocalDateTime format in a larger format

--- a/core/common/samples/format/LocalTimeFormatSamples.kt
+++ b/core/common/samples/format/LocalTimeFormatSamples.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.*
 import kotlinx.datetime.format.*
 import kotlin.test.*
 
-class LocalTimeFormatSamples {
+@PublishedApi internal class LocalTimeFormatSamples {
     @Test
     fun hhmmss() {
         // Defining a custom format for the local time

--- a/core/common/samples/format/UnicodeSamples.kt
+++ b/core/common/samples/format/UnicodeSamples.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.*
 import kotlinx.datetime.format.*
 import kotlin.test.*
 
-class UnicodeSamples {
+@PublishedApi internal class UnicodeSamples {
     @Test
     fun byUnicodePattern() {
         // Using the Unicode pattern to define a custom format and obtain the corresponding Kotlin code

--- a/core/common/samples/format/UtcOffsetFormatSamples.kt
+++ b/core/common/samples/format/UtcOffsetFormatSamples.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.*
 import kotlinx.datetime.format.*
 import kotlin.test.*
 
-class UtcOffsetFormatSamples {
+@PublishedApi internal class UtcOffsetFormatSamples {
     @Test
     fun isoOrGmt() {
         // Defining a custom format for the UTC offset


### PR DESCRIPTION
When trying to read documentation for a library that uses `@sample` in its KDocs, IDEA displays "Fetching Documentation..." indefinitely.

This commit doesn't fix that, but at least the documentation (including the samples) is readable by navigating to the definition of the thing in whose documentation you're interested.