### PR TITLE
Change ProGuard rules to suppress the library causing the problem

### DIFF
--- a/core/jvm/resources/META-INF/proguard/datetime.pro
+++ b/core/jvm/resources/META-INF/proguard/datetime.pro
@@ -1,11 +1,7 @@
 # We depend on kotlinx-serialization as compileOnly.
 # If the serializers don't get used, the library works properly even without the
 # kotlinx-serialization dependency, but Proguard emits warnings about datetime
-# classes mentioning some serialization-related entities.
-# These rules should not cause problems: if a project actually relies on
-# serialization, then much more than just these two classes will be required,
-# so telling Proguard not to worry if these two are missing will not prevent it
-# from emitting errors for code that does use serialization but somehow forgot
-# to depend on it.
--dontwarn kotlinx.serialization.KSerializer
--dontwarn kotlinx.serialization.Serializable
+# classes mentioning some serialization-related entities, for example:
+# Missing class kotlinx.serialization.KSerializer (referenced from: kotlinx.datetime.serializers.InstantIso8601Serializer)
+# Missing class kotlinx.serialization.Serializable (referenced from: kotlinx.datetime.Instant)
+-dontwarn kotlinx.datetime.**


### PR DESCRIPTION
 * Re https://github.com/Kotlin/kotlinx-datetime/pull/336 which fixed https://github.com/Kotlin/kotlinx-datetime/issues/297

This re-fixes https://github.com/Kotlin/kotlinx-datetime/issues/297. cc @dkhalanskyjb @MarcelReiter @LouisCAD

## Why?

The current solution on `master` is not broken, but it references the wrong library. Why? There are other libraries out there, in similar shoes to datetime, their problems will also be suppressed, by this library. This library is by no means authoritative to make a decision how other libraries should use `kotlinx.serialization`. Therefore it should be configuring ProGuard/R8 for itself. The other libraries need to be given a chance to detect and fix their own problems.

## Background

In general, if a user decides to suppress `kotlinx.serialization` with `-dontwarn`s in their project, that's a decision, but that's an end user decision, not a library one, it shouldn't apply to all users in the world.

## How?

The warning mentions that `Instant` is using `Serializable`, in this case `Instant` is doing the "wrong" thing, and therefore it shouldn't be `Serializable` that's being suppressed. Ideally `-dontwarn` would be powerful enough to combine the suppression of `datetime` + `serialization`, but until then we should be more specific about the suppression. The specificity in this case is `datetime`, because `serialization` is a more generic library.


## Testing

I used the https://github.com/MarcelReiter/dateTimeTest to confirm the fix. It only uses Instant, but each of the [datetime primitives](https://github.com/search?q=repo%3AKotlin%2Fkotlinx-datetime+%40Serializable&type=code) use `@Serializable` so the warning will apply to all, same with all `kotlinx.datetime.serializers` classes.
