### PR TITLE
Fix some files with dots in names being considered time zones

### DIFF
--- a/core/tzdbOnFilesystem/src/internal/TzdbOnFilesystem.kt
+++ b/core/tzdbOnFilesystem/src/internal/TzdbOnFilesystem.kt
@@ -30,24 +30,13 @@ internal class TzdbOnFilesystem(defaultTzdbPath: Path? = null): TimeZoneDatabase
 private val tabPaths = listOf("zone1970.tab", "zone.tab", "tab/zone_sun.tab")
 
 /** The files that sometimes lie in the `zoneinfo` directory but aren't actually time zones. */
-private val tzdbUnneededFiles = setOf(
+private val tzdbUnneededFiles: Regex = Regex(
     // taken from https://github.com/tzinfo/tzinfo/blob/9953fc092424d55deaea2dcdf6279943f3495724/lib/tzinfo/data_sources/zoneinfo_data_source.rb#L88C29-L97C21
-    "+VERSION",
-    "leapseconds",
-    "localtime",
-    "posix",
-    "posixrules",
-    "right",
-    "SECURITY",
-    "src",
-    "timeconfig",
+    "\\+VERSION|leapseconds|localtime|posix|posixrules|right|SECURITY|src|timeconfig|" +
+    // replicating https://github.com/tzinfo/tzinfo/blob/9953fc092424d55deaea2dcdf6279943f3495724/lib/tzinfo/data_sources/zoneinfo_data_source.rb#L442
+    ".*\\..*|" +
     // taken from https://github.com/HowardHinnant/date/blob/ab37c362e35267d6dee02cb47760f9e9c669d3be/src/tz.cpp#L2863-L2874
-    "Factory",
-    "iso3166.tab",
-    "zone.tab",
-    "zone1970.tab",
-    "tzdata.zi",
-    "leap-seconds.list"
+    "Factory"
 )
 
 /** The directories checked for a valid timezone database. */

--- a/core/tzdbOnFilesystem/src/internal/filesystem.kt
+++ b/core/tzdbOnFilesystem/src/internal/filesystem.kt
@@ -17,7 +17,7 @@ internal fun chaseSymlinks(name: String): Path? = memScoped {
 internal fun Path.containsFile(file: String): Boolean = access("$this/$file", F_OK) == 0
 
 internal fun Path.tryTraverseDirectory(
-    exclude: Set<String> = emptySet(),
+    exclude: Regex,
     stripLeadingComponents: Int = this.components.size,
     maxDepth: Int = 100,
     actionOnFile: (Path) -> Unit
@@ -29,7 +29,7 @@ internal fun Path.tryTraverseDirectory(
             val entry = readdir(handler) ?: break
             val name = entry.pointed.d_name.toKString()
             if (name == "." || name == "..") continue
-            if (name in exclude) continue
+            if (exclude.matches(name)) continue
             val path = Path(isAbsolute, components + name)
             val isDirectory = path.tryTraverseDirectory(
                 exclude, stripLeadingComponents, maxDepth = maxDepth - 1, actionOnFile


### PR DESCRIPTION
According to the authoritative implementation
https://github.com/tzinfo/tzinfo/blob/9953fc092424d55deaea2dcdf6279943f3495724/lib/tzinfo/data_sources/zoneinfo_data_source.rb#L442 , all files with dots in their names aren't valid time zones. Now we implement the same logic.