### PR TITLE
Rework the serializers using the DateTimeFormat API

### DIFF
--- a/core/api/kotlinx-datetime.api
+++ b/core/api/kotlinx-datetime.api
@@ -859,6 +859,15 @@ public final class kotlinx/datetime/serializers/DatePeriodIso8601Serializer : ko
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/DatePeriod;)V
 }
 
+public final class kotlinx/datetime/serializers/DatePeriodSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/DatePeriodSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/DatePeriod;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/DatePeriod;)V
+}
+
 public final class kotlinx/datetime/serializers/DateTimePeriodComponentSerializer : kotlinx/serialization/KSerializer {
 	public static final field INSTANCE Lkotlinx/datetime/serializers/DateTimePeriodComponentSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
@@ -870,6 +879,15 @@ public final class kotlinx/datetime/serializers/DateTimePeriodComponentSerialize
 
 public final class kotlinx/datetime/serializers/DateTimePeriodIso8601Serializer : kotlinx/serialization/KSerializer {
 	public static final field INSTANCE Lkotlinx/datetime/serializers/DateTimePeriodIso8601Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/DateTimePeriod;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/DateTimePeriod;)V
+}
+
+public final class kotlinx/datetime/serializers/DateTimePeriodSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/DateTimePeriodSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/DateTimePeriod;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
@@ -913,6 +931,52 @@ public final class kotlinx/datetime/serializers/FixedOffsetTimeZoneSerializer : 
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/FixedOffsetTimeZone;)V
 }
 
+public abstract class kotlinx/datetime/serializers/FormattedInstantSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/lang/String;Lkotlinx/datetime/format/DateTimeFormat;)V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/Instant;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/Instant;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class kotlinx/datetime/serializers/FormattedLocalDateSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/lang/String;Lkotlinx/datetime/format/DateTimeFormat;)V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/LocalDate;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalDate;)V
+}
+
+public abstract class kotlinx/datetime/serializers/FormattedLocalDateTimeSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/lang/String;Lkotlinx/datetime/format/DateTimeFormat;)V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/LocalDateTime;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalDateTime;)V
+}
+
+public abstract class kotlinx/datetime/serializers/FormattedLocalTimeSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/lang/String;Lkotlinx/datetime/format/DateTimeFormat;)V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/LocalTime;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalTime;)V
+}
+
+public abstract class kotlinx/datetime/serializers/FormattedUtcOffsetSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/lang/String;Lkotlinx/datetime/format/DateTimeFormat;)V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/UtcOffset;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/UtcOffset;)V
+}
+
 public final class kotlinx/datetime/serializers/InstantComponentSerializer : kotlinx/serialization/KSerializer {
 	public static final field INSTANCE Lkotlinx/datetime/serializers/InstantComponentSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
@@ -924,6 +988,15 @@ public final class kotlinx/datetime/serializers/InstantComponentSerializer : kot
 
 public final class kotlinx/datetime/serializers/InstantIso8601Serializer : kotlinx/serialization/KSerializer {
 	public static final field INSTANCE Lkotlinx/datetime/serializers/InstantIso8601Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/Instant;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/Instant;)V
+}
+
+public final class kotlinx/datetime/serializers/InstantSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/InstantSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/Instant;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
@@ -949,6 +1022,15 @@ public final class kotlinx/datetime/serializers/LocalDateIso8601Serializer : kot
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalDate;)V
 }
 
+public final class kotlinx/datetime/serializers/LocalDateSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/LocalDateSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/LocalDate;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalDate;)V
+}
+
 public final class kotlinx/datetime/serializers/LocalDateTimeComponentSerializer : kotlinx/serialization/KSerializer {
 	public static final field INSTANCE Lkotlinx/datetime/serializers/LocalDateTimeComponentSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
@@ -967,6 +1049,15 @@ public final class kotlinx/datetime/serializers/LocalDateTimeIso8601Serializer :
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalDateTime;)V
 }
 
+public final class kotlinx/datetime/serializers/LocalDateTimeSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/LocalDateTimeSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/LocalDateTime;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalDateTime;)V
+}
+
 public final class kotlinx/datetime/serializers/LocalTimeComponentSerializer : kotlinx/serialization/KSerializer {
 	public static final field INSTANCE Lkotlinx/datetime/serializers/LocalTimeComponentSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
@@ -978,6 +1069,15 @@ public final class kotlinx/datetime/serializers/LocalTimeComponentSerializer : k
 
 public final class kotlinx/datetime/serializers/LocalTimeIso8601Serializer : kotlinx/serialization/KSerializer {
 	public static final field INSTANCE Lkotlinx/datetime/serializers/LocalTimeIso8601Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/LocalTime;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/LocalTime;)V
+}
+
+public final class kotlinx/datetime/serializers/LocalTimeSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/LocalTimeSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/LocalTime;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
@@ -1019,6 +1119,15 @@ public final class kotlinx/datetime/serializers/TimeZoneSerializer : kotlinx/ser
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/TimeZone;)V
+}
+
+public final class kotlinx/datetime/serializers/UtcOffsetIso8601Serializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lkotlinx/datetime/serializers/UtcOffsetIso8601Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/datetime/UtcOffset;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/datetime/UtcOffset;)V
 }
 
 public final class kotlinx/datetime/serializers/UtcOffsetSerializer : kotlinx/serialization/KSerializer {

--- a/core/api/kotlinx-datetime.klib.api
+++ b/core/api/kotlinx-datetime.klib.api
@@ -135,6 +135,57 @@ sealed interface kotlinx.datetime.format/DateTimeFormatBuilder { // kotlinx.date
     }
 }
 
+abstract class kotlinx.datetime.serializers/FormattedInstantSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/Instant> { // kotlinx.datetime.serializers/FormattedInstantSerializer|null[0]
+    constructor <init>(kotlin/String, kotlinx.datetime.format/DateTimeFormat<kotlinx.datetime.format/DateTimeComponents>) // kotlinx.datetime.serializers/FormattedInstantSerializer.<init>|<init>(kotlin.String;kotlinx.datetime.format.DateTimeFormat<kotlinx.datetime.format.DateTimeComponents>){}[0]
+
+    open val descriptor // kotlinx.datetime.serializers/FormattedInstantSerializer.descriptor|{}descriptor[0]
+        open fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/FormattedInstantSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    open fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/Instant // kotlinx.datetime.serializers/FormattedInstantSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    open fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/Instant) // kotlinx.datetime.serializers/FormattedInstantSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.Instant){}[0]
+    open fun toString(): kotlin/String // kotlinx.datetime.serializers/FormattedInstantSerializer.toString|toString(){}[0]
+}
+
+abstract class kotlinx.datetime.serializers/FormattedLocalDateSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/LocalDate> { // kotlinx.datetime.serializers/FormattedLocalDateSerializer|null[0]
+    constructor <init>(kotlin/String, kotlinx.datetime.format/DateTimeFormat<kotlinx.datetime/LocalDate>) // kotlinx.datetime.serializers/FormattedLocalDateSerializer.<init>|<init>(kotlin.String;kotlinx.datetime.format.DateTimeFormat<kotlinx.datetime.LocalDate>){}[0]
+
+    open val descriptor // kotlinx.datetime.serializers/FormattedLocalDateSerializer.descriptor|{}descriptor[0]
+        open fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/FormattedLocalDateSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    open fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/LocalDate // kotlinx.datetime.serializers/FormattedLocalDateSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    open fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/LocalDate) // kotlinx.datetime.serializers/FormattedLocalDateSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.LocalDate){}[0]
+}
+
+abstract class kotlinx.datetime.serializers/FormattedLocalDateTimeSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/LocalDateTime> { // kotlinx.datetime.serializers/FormattedLocalDateTimeSerializer|null[0]
+    constructor <init>(kotlin/String, kotlinx.datetime.format/DateTimeFormat<kotlinx.datetime/LocalDateTime>) // kotlinx.datetime.serializers/FormattedLocalDateTimeSerializer.<init>|<init>(kotlin.String;kotlinx.datetime.format.DateTimeFormat<kotlinx.datetime.LocalDateTime>){}[0]
+
+    open val descriptor // kotlinx.datetime.serializers/FormattedLocalDateTimeSerializer.descriptor|{}descriptor[0]
+        open fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/FormattedLocalDateTimeSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    open fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/LocalDateTime // kotlinx.datetime.serializers/FormattedLocalDateTimeSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    open fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/LocalDateTime) // kotlinx.datetime.serializers/FormattedLocalDateTimeSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.LocalDateTime){}[0]
+}
+
+abstract class kotlinx.datetime.serializers/FormattedLocalTimeSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/LocalTime> { // kotlinx.datetime.serializers/FormattedLocalTimeSerializer|null[0]
+    constructor <init>(kotlin/String, kotlinx.datetime.format/DateTimeFormat<kotlinx.datetime/LocalTime>) // kotlinx.datetime.serializers/FormattedLocalTimeSerializer.<init>|<init>(kotlin.String;kotlinx.datetime.format.DateTimeFormat<kotlinx.datetime.LocalTime>){}[0]
+
+    open val descriptor // kotlinx.datetime.serializers/FormattedLocalTimeSerializer.descriptor|{}descriptor[0]
+        open fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/FormattedLocalTimeSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    open fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/LocalTime // kotlinx.datetime.serializers/FormattedLocalTimeSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    open fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/LocalTime) // kotlinx.datetime.serializers/FormattedLocalTimeSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.LocalTime){}[0]
+}
+
+abstract class kotlinx.datetime.serializers/FormattedUtcOffsetSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/UtcOffset> { // kotlinx.datetime.serializers/FormattedUtcOffsetSerializer|null[0]
+    constructor <init>(kotlin/String, kotlinx.datetime.format/DateTimeFormat<kotlinx.datetime/UtcOffset>) // kotlinx.datetime.serializers/FormattedUtcOffsetSerializer.<init>|<init>(kotlin.String;kotlinx.datetime.format.DateTimeFormat<kotlinx.datetime.UtcOffset>){}[0]
+
+    open val descriptor // kotlinx.datetime.serializers/FormattedUtcOffsetSerializer.descriptor|{}descriptor[0]
+        open fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/FormattedUtcOffsetSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    open fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/UtcOffset // kotlinx.datetime.serializers/FormattedUtcOffsetSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    open fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/UtcOffset) // kotlinx.datetime.serializers/FormattedUtcOffsetSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.UtcOffset){}[0]
+}
+
 final class kotlinx.datetime.format/DateTimeComponents { // kotlinx.datetime.format/DateTimeComponents|null[0]
     final var amPm // kotlinx.datetime.format/DateTimeComponents.amPm|{}amPm[0]
         final fun <get-amPm>(): kotlinx.datetime.format/AmPmMarker? // kotlinx.datetime.format/DateTimeComponents.amPm.<get-amPm>|<get-amPm>(){}[0]
@@ -695,6 +746,14 @@ final object kotlinx.datetime.serializers/DatePeriodIso8601Serializer : kotlinx.
     final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/DatePeriod) // kotlinx.datetime.serializers/DatePeriodIso8601Serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.DatePeriod){}[0]
 }
 
+final object kotlinx.datetime.serializers/DatePeriodSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/DatePeriod> { // kotlinx.datetime.serializers/DatePeriodSerializer|null[0]
+    final val descriptor // kotlinx.datetime.serializers/DatePeriodSerializer.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/DatePeriodSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/DatePeriod // kotlinx.datetime.serializers/DatePeriodSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/DatePeriod) // kotlinx.datetime.serializers/DatePeriodSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.DatePeriod){}[0]
+}
+
 final object kotlinx.datetime.serializers/DateTimePeriodComponentSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/DateTimePeriod> { // kotlinx.datetime.serializers/DateTimePeriodComponentSerializer|null[0]
     final val descriptor // kotlinx.datetime.serializers/DateTimePeriodComponentSerializer.descriptor|{}descriptor[0]
         final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/DateTimePeriodComponentSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
@@ -709,6 +768,14 @@ final object kotlinx.datetime.serializers/DateTimePeriodIso8601Serializer : kotl
 
     final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/DateTimePeriod // kotlinx.datetime.serializers/DateTimePeriodIso8601Serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
     final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/DateTimePeriod) // kotlinx.datetime.serializers/DateTimePeriodIso8601Serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.DateTimePeriod){}[0]
+}
+
+final object kotlinx.datetime.serializers/DateTimePeriodSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/DateTimePeriod> { // kotlinx.datetime.serializers/DateTimePeriodSerializer|null[0]
+    final val descriptor // kotlinx.datetime.serializers/DateTimePeriodSerializer.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/DateTimePeriodSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/DateTimePeriod // kotlinx.datetime.serializers/DateTimePeriodSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/DateTimePeriod) // kotlinx.datetime.serializers/DateTimePeriodSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.DateTimePeriod){}[0]
 }
 
 final object kotlinx.datetime.serializers/DateTimeUnitSerializer : kotlinx.serialization.internal/AbstractPolymorphicSerializer<kotlinx.datetime/DateTimeUnit> { // kotlinx.datetime.serializers/DateTimeUnitSerializer|null[0]
@@ -761,6 +828,14 @@ final object kotlinx.datetime.serializers/InstantIso8601Serializer : kotlinx.ser
     final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/Instant) // kotlinx.datetime.serializers/InstantIso8601Serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.Instant){}[0]
 }
 
+final object kotlinx.datetime.serializers/InstantSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/Instant> { // kotlinx.datetime.serializers/InstantSerializer|null[0]
+    final val descriptor // kotlinx.datetime.serializers/InstantSerializer.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/InstantSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/Instant // kotlinx.datetime.serializers/InstantSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/Instant) // kotlinx.datetime.serializers/InstantSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.Instant){}[0]
+}
+
 final object kotlinx.datetime.serializers/LocalDateComponentSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/LocalDate> { // kotlinx.datetime.serializers/LocalDateComponentSerializer|null[0]
     final val descriptor // kotlinx.datetime.serializers/LocalDateComponentSerializer.descriptor|{}descriptor[0]
         final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/LocalDateComponentSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
@@ -775,6 +850,14 @@ final object kotlinx.datetime.serializers/LocalDateIso8601Serializer : kotlinx.s
 
     final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/LocalDate // kotlinx.datetime.serializers/LocalDateIso8601Serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
     final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/LocalDate) // kotlinx.datetime.serializers/LocalDateIso8601Serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.LocalDate){}[0]
+}
+
+final object kotlinx.datetime.serializers/LocalDateSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/LocalDate> { // kotlinx.datetime.serializers/LocalDateSerializer|null[0]
+    final val descriptor // kotlinx.datetime.serializers/LocalDateSerializer.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/LocalDateSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/LocalDate // kotlinx.datetime.serializers/LocalDateSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/LocalDate) // kotlinx.datetime.serializers/LocalDateSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.LocalDate){}[0]
 }
 
 final object kotlinx.datetime.serializers/LocalDateTimeComponentSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/LocalDateTime> { // kotlinx.datetime.serializers/LocalDateTimeComponentSerializer|null[0]
@@ -793,6 +876,14 @@ final object kotlinx.datetime.serializers/LocalDateTimeIso8601Serializer : kotli
     final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/LocalDateTime) // kotlinx.datetime.serializers/LocalDateTimeIso8601Serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.LocalDateTime){}[0]
 }
 
+final object kotlinx.datetime.serializers/LocalDateTimeSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/LocalDateTime> { // kotlinx.datetime.serializers/LocalDateTimeSerializer|null[0]
+    final val descriptor // kotlinx.datetime.serializers/LocalDateTimeSerializer.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/LocalDateTimeSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/LocalDateTime // kotlinx.datetime.serializers/LocalDateTimeSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/LocalDateTime) // kotlinx.datetime.serializers/LocalDateTimeSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.LocalDateTime){}[0]
+}
+
 final object kotlinx.datetime.serializers/LocalTimeComponentSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/LocalTime> { // kotlinx.datetime.serializers/LocalTimeComponentSerializer|null[0]
     final val descriptor // kotlinx.datetime.serializers/LocalTimeComponentSerializer.descriptor|{}descriptor[0]
         final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/LocalTimeComponentSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
@@ -807,6 +898,14 @@ final object kotlinx.datetime.serializers/LocalTimeIso8601Serializer : kotlinx.s
 
     final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/LocalTime // kotlinx.datetime.serializers/LocalTimeIso8601Serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
     final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/LocalTime) // kotlinx.datetime.serializers/LocalTimeIso8601Serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.LocalTime){}[0]
+}
+
+final object kotlinx.datetime.serializers/LocalTimeSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/LocalTime> { // kotlinx.datetime.serializers/LocalTimeSerializer|null[0]
+    final val descriptor // kotlinx.datetime.serializers/LocalTimeSerializer.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/LocalTimeSerializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/LocalTime // kotlinx.datetime.serializers/LocalTimeSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/LocalTime) // kotlinx.datetime.serializers/LocalTimeSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.LocalTime){}[0]
 }
 
 final object kotlinx.datetime.serializers/MonthBasedDateTimeUnitSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/DateTimeUnit.MonthBased> { // kotlinx.datetime.serializers/MonthBasedDateTimeUnitSerializer|null[0]
@@ -839,6 +938,14 @@ final object kotlinx.datetime.serializers/TimeZoneSerializer : kotlinx.serializa
 
     final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/TimeZone // kotlinx.datetime.serializers/TimeZoneSerializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
     final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/TimeZone) // kotlinx.datetime.serializers/TimeZoneSerializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.TimeZone){}[0]
+}
+
+final object kotlinx.datetime.serializers/UtcOffsetIso8601Serializer : kotlinx.serialization/KSerializer<kotlinx.datetime/UtcOffset> { // kotlinx.datetime.serializers/UtcOffsetIso8601Serializer|null[0]
+    final val descriptor // kotlinx.datetime.serializers/UtcOffsetIso8601Serializer.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // kotlinx.datetime.serializers/UtcOffsetIso8601Serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+    final fun deserialize(kotlinx.serialization.encoding/Decoder): kotlinx.datetime/UtcOffset // kotlinx.datetime.serializers/UtcOffsetIso8601Serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+    final fun serialize(kotlinx.serialization.encoding/Encoder, kotlinx.datetime/UtcOffset) // kotlinx.datetime.serializers/UtcOffsetIso8601Serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;kotlinx.datetime.UtcOffset){}[0]
 }
 
 final object kotlinx.datetime.serializers/UtcOffsetSerializer : kotlinx.serialization/KSerializer<kotlinx.datetime/UtcOffset> { // kotlinx.datetime.serializers/UtcOffsetSerializer|null[0]

--- a/core/common/src/DateTimePeriod.kt
+++ b/core/common/src/DateTimePeriod.kt
@@ -9,7 +9,9 @@ import kotlinx.datetime.internal.*
 import kotlinx.datetime.serializers.DatePeriodIso8601Serializer
 import kotlinx.datetime.serializers.DateTimePeriodIso8601Serializer
 import kotlinx.datetime.serializers.DatePeriodComponentSerializer
+import kotlinx.datetime.serializers.DatePeriodSerializer
 import kotlinx.datetime.serializers.DateTimePeriodComponentSerializer
+import kotlinx.datetime.serializers.DateTimePeriodSerializer
 import kotlin.math.*
 import kotlin.time.Duration
 import kotlinx.serialization.Serializable
@@ -63,13 +65,14 @@ import kotlinx.serialization.Serializable
  * `DateTimePeriod` can also be returned as the result of instant arithmetic operations (see [Instant.periodUntil]).
  *
  * Additionally, there are several `kotlinx-serialization` serializers for [DateTimePeriod]:
- * - [DateTimePeriodIso8601Serializer] for the ISO 8601 format;
+ * - The default serializer, delegating to [toString] and [parse].
+ * - [DateTimePeriodIso8601Serializer] for the ISO 8601 format.
  * - [DateTimePeriodComponentSerializer]  for an object with components.
  *
  * @sample kotlinx.datetime.test.samples.DateTimePeriodSamples.construction
  * @sample kotlinx.datetime.test.samples.DateTimePeriodSamples.simpleParsingAndFormatting
  */
-@Serializable(with = DateTimePeriodIso8601Serializer::class)
+@Serializable(with = DateTimePeriodSerializer::class)
 // TODO: could be error-prone without explicitly named params
 public sealed class DateTimePeriod {
     internal abstract val totalMonths: Long
@@ -430,7 +433,7 @@ public fun String.toDateTimePeriod(): DateTimePeriod = DateTimePeriod.parse(this
  *
  * @sample kotlinx.datetime.test.samples.DatePeriodSamples.simpleParsingAndFormatting
  */
-@Serializable(with = DatePeriodIso8601Serializer::class)
+@Serializable(with = DatePeriodSerializer::class)
 public class DatePeriod internal constructor(
     internal override val totalMonths: Long,
     override val days: Int,

--- a/core/common/src/Instant.kt
+++ b/core/common/src/Instant.kt
@@ -7,8 +7,7 @@ package kotlinx.datetime
 
 import kotlinx.datetime.format.*
 import kotlinx.datetime.internal.*
-import kotlinx.datetime.serializers.InstantIso8601Serializer
-import kotlinx.datetime.serializers.InstantComponentSerializer
+import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 import kotlin.time.*
 
@@ -189,12 +188,13 @@ import kotlin.time.*
  * ```
  *
  * Additionally, there are several `kotlinx-serialization` serializers for [Instant]:
+ * - The default serializer, delegating to [toString] and [parse].
  * - [InstantIso8601Serializer] for the ISO 8601 extended format.
  * - [InstantComponentSerializer] for an object with components.
  *
  * @see LocalDateTime for a user-visible representation of moments in time in an unspecified time zone.
  */
-@Serializable(with = InstantIso8601Serializer::class)
+@Serializable(with = InstantSerializer::class)
 public expect class Instant : Comparable<Instant> {
 
     /**

--- a/core/common/src/LocalDate.kt
+++ b/core/common/src/LocalDate.kt
@@ -57,6 +57,7 @@ import kotlin.internal.*
  * See sample 4.
  *
  * Additionally, there are several `kotlinx-serialization` serializers for [LocalDate]:
+ * - The default serializer, delegating to [toString] and [parse].
  * - [LocalDateIso8601Serializer] for the ISO 8601 extended format.
  * - [LocalDateComponentSerializer] for an object with components.
  *
@@ -65,7 +66,7 @@ import kotlin.internal.*
  * @sample kotlinx.datetime.test.samples.LocalDateSamples.simpleParsingAndFormatting
  * @sample kotlinx.datetime.test.samples.LocalDateSamples.customFormat
  */
-@Serializable(with = LocalDateIso8601Serializer::class)
+@Serializable(with = LocalDateSerializer::class)
 public expect class LocalDate : Comparable<LocalDate> {
     public companion object {
         /**

--- a/core/common/src/LocalDateTime.kt
+++ b/core/common/src/LocalDateTime.kt
@@ -8,8 +8,7 @@
 package kotlinx.datetime
 
 import kotlinx.datetime.format.*
-import kotlinx.datetime.serializers.LocalDateTimeIso8601Serializer
-import kotlinx.datetime.serializers.LocalDateTimeComponentSerializer
+import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 import kotlin.internal.*
 import kotlin.jvm.JvmMultifileClass
@@ -99,6 +98,7 @@ import kotlin.jvm.JvmName
  * See sample 4.
  *
  * Additionally, there are several `kotlinx-serialization` serializers for [LocalDateTime]:
+ * - The default serializer, delegating to [toString] and [parse].
  * - [LocalDateTimeIso8601Serializer] for the ISO 8601 extended format.
  * - [LocalDateTimeComponentSerializer] for an object with components.
  *
@@ -110,7 +110,7 @@ import kotlin.jvm.JvmName
  * @sample kotlinx.datetime.test.samples.LocalDateTimeSamples.simpleParsingAndFormatting
  * @sample kotlinx.datetime.test.samples.LocalDateTimeSamples.customFormat
  */
-@Serializable(with = LocalDateTimeIso8601Serializer::class)
+@Serializable(with = LocalDateTimeSerializer::class)
 public expect class LocalDateTime : Comparable<LocalDateTime> {
     public companion object {
 

--- a/core/common/src/LocalTime.kt
+++ b/core/common/src/LocalTime.kt
@@ -8,8 +8,7 @@
 package kotlinx.datetime
 
 import kotlinx.datetime.format.*
-import kotlinx.datetime.serializers.LocalTimeIso8601Serializer
-import kotlinx.datetime.serializers.LocalTimeComponentSerializer
+import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 import kotlin.internal.*
 import kotlin.jvm.JvmMultifileClass
@@ -72,6 +71,7 @@ import kotlin.jvm.JvmName
  * See sample 4.
  *
  * Additionally, there are several `kotlinx-serialization` serializers for [LocalTime]:
+ * - The default serializer, delegating to [toString] and [parse].
  * - [LocalTimeIso8601Serializer] for the ISO 8601 extended format,
  * - [LocalTimeComponentSerializer] for an object with components.
  *
@@ -80,7 +80,7 @@ import kotlin.jvm.JvmName
  * @sample kotlinx.datetime.test.samples.LocalTimeSamples.simpleParsingAndFormatting
  * @sample kotlinx.datetime.test.samples.LocalTimeSamples.customFormat
  */
-@Serializable(LocalTimeIso8601Serializer::class)
+@Serializable(LocalTimeSerializer::class)
 public expect class LocalTime : Comparable<LocalTime> {
     public companion object {
 

--- a/core/common/src/UtcOffset.kt
+++ b/core/common/src/UtcOffset.kt
@@ -6,7 +6,7 @@
 package kotlinx.datetime
 
 import kotlinx.datetime.format.*
-import kotlinx.datetime.serializers.UtcOffsetSerializer
+import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 
 /**
@@ -47,12 +47,14 @@ import kotlinx.serialization.Serializable
  * [parse] and [UtcOffset.format] both support custom formats created with [Format] or defined in [Formats].
  * See sample 3.
  *
- * To serialize and deserialize [UtcOffset] values with `kotlinx-serialization`, use the [UtcOffsetSerializer].
+ * To serialize and deserialize [UtcOffset] values with `kotlinx-serialization`, use the default serializer,
+ * or [UtcOffsetIso8601Serializer] for the ISO 8601 format explicitly.
  *
  * @sample kotlinx.datetime.test.samples.UtcOffsetSamples.construction
  * @sample kotlinx.datetime.test.samples.UtcOffsetSamples.simpleParsingAndFormatting
  * @sample kotlinx.datetime.test.samples.UtcOffsetSamples.customFormat
  */
+@Suppress("DEPRECATION")
 @Serializable(with = UtcOffsetSerializer::class)
 public expect class UtcOffset {
     /**

--- a/core/common/src/serializers/DateTimePeriodSerializers.kt
+++ b/core/common/src/serializers/DateTimePeriodSerializers.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.encoding.*
 public object DateTimePeriodComponentSerializer: KSerializer<DateTimePeriod> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("kotlinx.datetime.DateTimePeriod") {
+        buildClassSerialDescriptor("kotlinx.datetime.DateTimePeriod components") {
             element<Int>("years", isOptional = true)
             element<Int>("months", isOptional = true)
             element<Int>("days", isOptional = true)
@@ -81,7 +81,7 @@ public object DateTimePeriodComponentSerializer: KSerializer<DateTimePeriod> {
 public object DateTimePeriodIso8601Serializer: KSerializer<DateTimePeriod> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("kotlinx.datetime.DateTimePeriod", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.datetime.DateTimePeriod ISO", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): DateTimePeriod =
         DateTimePeriod.parse(decoder.decodeString())
@@ -110,7 +110,7 @@ public object DatePeriodComponentSerializer: KSerializer<DatePeriod> {
     private fun unexpectedNonzero(fieldName: String, value: Int) = unexpectedNonzero(fieldName, value.toLong())
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("kotlinx.datetime.DatePeriod") {
+        buildClassSerialDescriptor("kotlinx.datetime.DatePeriod components") {
             element<Int>("years", isOptional = true)
             element<Int>("months", isOptional = true)
             element<Int>("days", isOptional = true)
@@ -166,7 +166,7 @@ public object DatePeriodComponentSerializer: KSerializer<DatePeriod> {
 public object DatePeriodIso8601Serializer: KSerializer<DatePeriod> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("kotlinx.datetime.DatePeriod", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.datetime.DatePeriod ISO", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): DatePeriod =
         when (val period = DateTimePeriod.parse(decoder.decodeString())) {
@@ -178,4 +178,16 @@ public object DatePeriodIso8601Serializer: KSerializer<DatePeriod> {
         encoder.encodeString(value.toString())
     }
 
+}
+
+@PublishedApi
+internal object DateTimePeriodSerializer: KSerializer<DateTimePeriod> by DateTimePeriodIso8601Serializer {
+    override val descriptor =
+        PrimitiveSerialDescriptor("kotlinx.datetime.DateTimePeriod", PrimitiveKind.STRING)
+}
+
+@PublishedApi
+internal object DatePeriodSerializer: KSerializer<DatePeriod> by DatePeriodIso8601Serializer {
+    override val descriptor =
+        PrimitiveSerialDescriptor("kotlinx.datetime.DatePeriod", PrimitiveKind.STRING)
 }

--- a/core/common/src/serializers/DateTimePeriodSerializers.kt
+++ b/core/common/src/serializers/DateTimePeriodSerializers.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.encoding.*
 public object DateTimePeriodComponentSerializer: KSerializer<DateTimePeriod> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("kotlinx.datetime.DateTimePeriod components") {
+        buildClassSerialDescriptor("kotlinx.datetime.DateTimePeriod/components") {
             element<Int>("years", isOptional = true)
             element<Int>("months", isOptional = true)
             element<Int>("days", isOptional = true)
@@ -81,7 +81,7 @@ public object DateTimePeriodComponentSerializer: KSerializer<DateTimePeriod> {
 public object DateTimePeriodIso8601Serializer: KSerializer<DateTimePeriod> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("kotlinx.datetime.DateTimePeriod ISO", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.datetime.DateTimePeriod/ISO", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): DateTimePeriod =
         DateTimePeriod.parse(decoder.decodeString())
@@ -110,7 +110,7 @@ public object DatePeriodComponentSerializer: KSerializer<DatePeriod> {
     private fun unexpectedNonzero(fieldName: String, value: Int) = unexpectedNonzero(fieldName, value.toLong())
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("kotlinx.datetime.DatePeriod components") {
+        buildClassSerialDescriptor("kotlinx.datetime.DatePeriod/components") {
             element<Int>("years", isOptional = true)
             element<Int>("months", isOptional = true)
             element<Int>("days", isOptional = true)
@@ -166,7 +166,7 @@ public object DatePeriodComponentSerializer: KSerializer<DatePeriod> {
 public object DatePeriodIso8601Serializer: KSerializer<DatePeriod> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("kotlinx.datetime.DatePeriod ISO", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.datetime.DatePeriod/ISO", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): DatePeriod =
         when (val period = DateTimePeriod.parse(decoder.decodeString())) {

--- a/core/common/src/serializers/InstantSerializers.kt
+++ b/core/common/src/serializers/InstantSerializers.kt
@@ -92,14 +92,14 @@ public object InstantComponentSerializer : KSerializer<Instant> {
  * This serializer is abstract and must be subclassed to provide a concrete serializer.
  * Example:
  * ```
- * object Rfc1123InstantSerializer : CustomInstantSerializer(DateTimeComponents.Formats.RFC_1123)
+ * object Rfc1123InstantSerializer : FormattedInstantSerializer(DateTimeComponents.Formats.RFC_1123)
  * ```
  *
  * Note that [Instant] is [kotlinx.serialization.Serializable] by default,
  * so it is not necessary to create custom serializers when the format is not important.
  * Additionally, [InstantIso8601Serializer] is provided for the ISO 8601 format.
  */
-public abstract class CustomInstantSerializer(
+public abstract class FormattedInstantSerializer(
     private val format: DateTimeFormat<DateTimeComponents>,
 ) : KSerializer<Instant> {
 

--- a/core/common/src/serializers/InstantSerializers.kt
+++ b/core/common/src/serializers/InstantSerializers.kt
@@ -22,7 +22,7 @@ import kotlinx.serialization.encoding.*
 public object InstantIso8601Serializer : KSerializer<Instant> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("kotlinx.datetime.Instant", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.datetime.Instant ISO", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): Instant =
         Instant.parse(decoder.decodeString(), DateTimeComponents.Formats.ISO_DATE_TIME_OFFSET)
@@ -41,7 +41,7 @@ public object InstantIso8601Serializer : KSerializer<Instant> {
 public object InstantComponentSerializer : KSerializer<Instant> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("kotlinx.datetime.Instant") {
+        buildClassSerialDescriptor("kotlinx.datetime.Instant components") {
             element<Long>("epochSeconds")
             element<Long>("nanosecondsOfSecond", isOptional = true)
         }

--- a/core/common/src/serializers/InstantSerializers.kt
+++ b/core/common/src/serializers/InstantSerializers.kt
@@ -17,8 +17,7 @@ import kotlinx.serialization.encoding.*
  *
  * JSON example: `"2020-12-09T09:16:56.000124Z"`
  *
- * @see Instant.toString
- * @see Instant.parse
+ * @see DateTimeComponents.Formats.ISO_DATE_TIME_OFFSET
  */
 public object InstantIso8601Serializer : KSerializer<Instant> {
 
@@ -26,10 +25,10 @@ public object InstantIso8601Serializer : KSerializer<Instant> {
         PrimitiveSerialDescriptor("kotlinx.datetime.Instant", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): Instant =
-        Instant.parse(decoder.decodeString())
+        Instant.parse(decoder.decodeString(), DateTimeComponents.Formats.ISO_DATE_TIME_OFFSET)
 
     override fun serialize(encoder: Encoder, value: Instant) {
-        encoder.encodeString(value.toString())
+        encoder.encodeString(value.format(DateTimeComponents.Formats.ISO_DATE_TIME_OFFSET))
     }
 
 }
@@ -124,4 +123,23 @@ public abstract class FormattedInstantSerializer(
 
     @OptIn(ExperimentalSerializationApi::class)
     override fun toString(): String = descriptor.serialName
+}
+
+/**
+ * A serializer for [Instant] that uses the default [Instant.toString]/[Instant.parse].
+ *
+ * JSON example: `"2020-12-09T09:16:56.000124Z"`
+ */
+@PublishedApi internal object InstantSerializer : KSerializer<Instant> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("kotlinx.datetime.Instant", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): Instant =
+        Instant.parse(decoder.decodeString())
+
+    override fun serialize(encoder: Encoder, value: Instant) {
+        encoder.encodeString(value.toString())
+    }
+
 }

--- a/core/common/src/serializers/InstantSerializers.kt
+++ b/core/common/src/serializers/InstantSerializers.kt
@@ -22,7 +22,7 @@ import kotlinx.serialization.encoding.*
 public object InstantIso8601Serializer : KSerializer<Instant> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("kotlinx.datetime.Instant ISO", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.datetime.Instant/ISO", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): Instant =
         Instant.parse(decoder.decodeString(), DateTimeComponents.Formats.ISO_DATE_TIME_OFFSET)
@@ -41,7 +41,7 @@ public object InstantIso8601Serializer : KSerializer<Instant> {
 public object InstantComponentSerializer : KSerializer<Instant> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("kotlinx.datetime.Instant components") {
+        buildClassSerialDescriptor("kotlinx.datetime.Instant/components") {
             element<Long>("epochSeconds")
             element<Long>("nanosecondsOfSecond", isOptional = true)
         }
@@ -112,7 +112,7 @@ public abstract class FormattedInstantSerializer(
     private val format: DateTimeFormat<DateTimeComponents>,
 ) : KSerializer<Instant> {
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("kotlinx.datetime.Instant serializer $name", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor("kotlinx.datetime.Instant/serializer/$name", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): Instant =
         Instant.parse(decoder.decodeString(), format)

--- a/core/common/src/serializers/InstantSerializers.kt
+++ b/core/common/src/serializers/InstantSerializers.kt
@@ -85,7 +85,7 @@ public object InstantComponentSerializer : KSerializer<Instant> {
  * See [Instant.parse] for details of how deserialization is performed.
  *
  * [name] is the name of the serializer.
- * The [SerialDescriptor.serialName] of the resulting serializer is `kotlinx.datetime.Instant serializer `[name].
+ * The [SerialDescriptor.serialName] of the resulting serializer is `kotlinx.datetime.Instant/serializer/`[name].
  * [SerialDescriptor.serialName] must be unique across all serializers in the same serialization context.
  * When defining a serializer in a library, it is recommended to use the fully qualified class name in [name]
  * to avoid conflicts with serializers defined by other libraries and client code.

--- a/core/common/src/serializers/LocalDateSerializers.kt
+++ b/core/common/src/serializers/LocalDateSerializers.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.encoding.*
  * @see LocalDate.Formats.ISO
  */
 public object LocalDateIso8601Serializer : KSerializer<LocalDate>
-by LocalDate.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDate")
+by LocalDate.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDate ISO")
 
 /**
  * A serializer for [LocalDate] that represents a value as its components.
@@ -29,7 +29,7 @@ by LocalDate.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDate")
 public object LocalDateComponentSerializer: KSerializer<LocalDate> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("kotlinx.datetime.LocalDate") {
+        buildClassSerialDescriptor("kotlinx.datetime.LocalDate components") {
             element<Int>("year")
             element<Short>("month")
             element<Short>("day")

--- a/core/common/src/serializers/LocalDateSerializers.kt
+++ b/core/common/src/serializers/LocalDateSerializers.kt
@@ -85,14 +85,14 @@ public object LocalDateComponentSerializer: KSerializer<LocalDate> {
  * This serializer is abstract and must be subclassed to provide a concrete serializer.
  * Example:
  * ```
- * object IsoBasicLocalDateSerializer : CustomLocalDateSerializer(LocalDate.Formats.ISO_BASIC)
+ * object IsoBasicLocalDateSerializer : FormattedLocalDateSerializer(LocalDate.Formats.ISO_BASIC)
  * ```
  *
  * Note that [LocalDate] is [kotlinx.serialization.Serializable] by default,
  * so it is not necessary to create custom serializers when the format is not important.
  * Additionally, [LocalDateIso8601Serializer] is provided for the ISO 8601 format.
  */
-public abstract class CustomLocalDateSerializer(
+public abstract class FormattedLocalDateSerializer(
     format: DateTimeFormat<LocalDate>,
 ) : KSerializer<LocalDate> by format.asKSerializer("kotlinx.datetime.LocalDate")
 

--- a/core/common/src/serializers/LocalDateSerializers.kt
+++ b/core/common/src/serializers/LocalDateSerializers.kt
@@ -16,22 +16,10 @@ import kotlinx.serialization.encoding.*
  *
  * JSON example: `"2020-01-01"`
  *
- * @see LocalDate.parse
- * @see LocalDate.toString
+ * @see LocalDate.Formats.ISO
  */
-public object LocalDateIso8601Serializer: KSerializer<LocalDate> {
-
-    override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("kotlinx.datetime.LocalDate", PrimitiveKind.STRING)
-
-    override fun deserialize(decoder: Decoder): LocalDate =
-        LocalDate.parse(decoder.decodeString())
-
-    override fun serialize(encoder: Encoder, value: LocalDate) {
-        encoder.encodeString(value.toString())
-    }
-
-}
+public object LocalDateIso8601Serializer : KSerializer<LocalDate>
+by LocalDate.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDate")
 
 /**
  * A serializer for [LocalDate] that represents a value as its components.
@@ -117,3 +105,23 @@ internal fun <T> DateTimeFormat<T>.asKSerializer(serialName: String): KSerialize
 
         override fun toString(): String = serialName
     }
+
+/**
+ * A serializer for [LocalDate] that uses the default [LocalDate.toString]/[LocalDate.parse].
+ *
+ * JSON example: `"2020-01-01"`
+ */
+@PublishedApi
+internal object LocalDateSerializer: KSerializer<LocalDate> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("kotlinx.datetime.LocalDate", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): LocalDate =
+        LocalDate.parse(decoder.decodeString())
+
+    override fun serialize(encoder: Encoder, value: LocalDate) {
+        encoder.encodeString(value.toString())
+    }
+
+}

--- a/core/common/src/serializers/LocalDateSerializers.kt
+++ b/core/common/src/serializers/LocalDateSerializers.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.encoding.*
  * @see LocalDate.Formats.ISO
  */
 public object LocalDateIso8601Serializer : KSerializer<LocalDate>
-by LocalDate.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDate ISO")
+by LocalDate.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDate/ISO")
 
 /**
  * A serializer for [LocalDate] that represents a value as its components.
@@ -29,7 +29,7 @@ by LocalDate.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDate ISO")
 public object LocalDateComponentSerializer: KSerializer<LocalDate> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("kotlinx.datetime.LocalDate components") {
+        buildClassSerialDescriptor("kotlinx.datetime.LocalDate/components") {
             element<Int>("year")
             element<Short>("month")
             element<Short>("day")
@@ -90,7 +90,7 @@ public object LocalDateComponentSerializer: KSerializer<LocalDate> {
  */
 public abstract class FormattedLocalDateSerializer(
     name: String, format: DateTimeFormat<LocalDate>
-) : KSerializer<LocalDate> by format.asKSerializer("kotlinx.datetime.LocalDate serializer $name")
+) : KSerializer<LocalDate> by format.asKSerializer("kotlinx.datetime.LocalDate/serializer/$name")
 
 internal fun <T> DateTimeFormat<T>.asKSerializer(serialName: String): KSerializer<T> =
     object : KSerializer<T> {

--- a/core/common/src/serializers/LocalDateSerializers.kt
+++ b/core/common/src/serializers/LocalDateSerializers.kt
@@ -71,7 +71,7 @@ public object LocalDateComponentSerializer: KSerializer<LocalDate> {
  * a custom [DateTimeFormat] to serialize and deserialize the value.
  *
  * [name] is the name of the serializer.
- * The [SerialDescriptor.serialName] of the resulting serializer is `kotlinx.datetime.LocalDate serializer `[name].
+ * The [SerialDescriptor.serialName] of the resulting serializer is `kotlinx.datetime.LocalDate/serializer/`[name].
  * [SerialDescriptor.serialName] must be unique across all serializers in the same serialization context.
  * When defining a serializer in a library, it is recommended to use the fully qualified class name in [name]
  * to avoid conflicts with serializers defined by other libraries and client code.

--- a/core/common/src/serializers/LocalDateTimeSerializers.kt
+++ b/core/common/src/serializers/LocalDateTimeSerializers.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.encoding.*
  * @see LocalDateTime.Formats.ISO
  */
 public object LocalDateTimeIso8601Serializer : KSerializer<LocalDateTime>
-by LocalDateTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDateTime")
+by LocalDateTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDateTime ISO")
 
 /**
  * A serializer for [LocalDateTime] that represents a value as its components.
@@ -29,7 +29,7 @@ by LocalDateTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDateTime")
 public object LocalDateTimeComponentSerializer: KSerializer<LocalDateTime> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("kotlinx.datetime.LocalDateTime") {
+        buildClassSerialDescriptor("kotlinx.datetime.LocalDateTime components") {
             element<Int>("year")
             element<Short>("month")
             element<Short>("day")

--- a/core/common/src/serializers/LocalDateTimeSerializers.kt
+++ b/core/common/src/serializers/LocalDateTimeSerializers.kt
@@ -107,7 +107,7 @@ public object LocalDateTimeComponentSerializer: KSerializer<LocalDateTime> {
  * This serializer is abstract and must be subclassed to provide a concrete serializer.
  * Example:
  * ```
- * object PythonDateTimeSerializer : CustomLocalDateTimeSerializer(LocalDateTime.Format {
+ * object PythonDateTimeSerializer : FormattedLocalDateTimeSerializer(LocalDateTime.Format {
  *     date(LocalDate.Formats.ISO)
  *     char(' ')
  *     time(LocalTime.Formats.ISO)
@@ -118,6 +118,6 @@ public object LocalDateTimeComponentSerializer: KSerializer<LocalDateTime> {
  * so it is not necessary to create custom serializers when the format is not important.
  * Additionally, [LocalDateTimeIso8601Serializer] is provided for the ISO 8601 format.
  */
-public abstract class CustomLocalDateTimeSerializer(
+public abstract class FormattedLocalDateTimeSerializer(
     format: DateTimeFormat<LocalDateTime>,
 ) : KSerializer<LocalDateTime> by format.asKSerializer("kotlinx.datetime.LocalDateTime")

--- a/core/common/src/serializers/LocalDateTimeSerializers.kt
+++ b/core/common/src/serializers/LocalDateTimeSerializers.kt
@@ -16,22 +16,10 @@ import kotlinx.serialization.encoding.*
  *
  * JSON example: `"2007-12-31T23:59:01"`
  *
- * @see LocalDateTime.parse
- * @see LocalDateTime.toString
+ * @see LocalDateTime.Formats.ISO
  */
-public object LocalDateTimeIso8601Serializer: KSerializer<LocalDateTime> {
-
-    override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("kotlinx.datetime.LocalDateTime", PrimitiveKind.STRING)
-
-    override fun deserialize(decoder: Decoder): LocalDateTime =
-        LocalDateTime.parse(decoder.decodeString())
-
-    override fun serialize(encoder: Encoder, value: LocalDateTime) {
-        encoder.encodeString(value.toString())
-    }
-
-}
+public object LocalDateTimeIso8601Serializer : KSerializer<LocalDateTime>
+by LocalDateTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDateTime")
 
 /**
  * A serializer for [LocalDateTime] that represents a value as its components.
@@ -130,3 +118,23 @@ public object LocalDateTimeComponentSerializer: KSerializer<LocalDateTime> {
 public abstract class FormattedLocalDateTimeSerializer(
     name: String, format: DateTimeFormat<LocalDateTime>
 ) : KSerializer<LocalDateTime> by format.asKSerializer("kotlinx.datetime.LocalDateTime serializer $name")
+
+/**
+ * A serializer for [LocalDateTime] that uses the default [LocalDateTime.toString]/[LocalDateTime.parse].
+ *
+ * JSON example: `"2007-12-31T23:59:01"`
+ */
+@PublishedApi
+internal object LocalDateTimeSerializer: KSerializer<LocalDateTime> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("kotlinx.datetime.LocalDateTime", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): LocalDateTime =
+        LocalDateTime.parse(decoder.decodeString())
+
+    override fun serialize(encoder: Encoder, value: LocalDateTime) {
+        encoder.encodeString(value.toString())
+    }
+
+}

--- a/core/common/src/serializers/LocalDateTimeSerializers.kt
+++ b/core/common/src/serializers/LocalDateTimeSerializers.kt
@@ -6,6 +6,7 @@
 package kotlinx.datetime.serializers
 
 import kotlinx.datetime.*
+import kotlinx.datetime.format.DateTimeFormat
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
@@ -98,3 +99,25 @@ public object LocalDateTimeComponentSerializer: KSerializer<LocalDateTime> {
     }
 
 }
+
+/**
+ * An abstract serializer for [LocalDateTime] values that uses
+ * a custom [DateTimeFormat] to serialize and deserialize the value.
+ *
+ * This serializer is abstract and must be subclassed to provide a concrete serializer.
+ * Example:
+ * ```
+ * object PythonDateTimeSerializer : CustomLocalDateTimeSerializer(LocalDateTime.Format {
+ *     date(LocalDate.Formats.ISO)
+ *     char(' ')
+ *     time(LocalTime.Formats.ISO)
+ * })
+ * ```
+ *
+ * Note that [LocalDateTime] is [kotlinx.serialization.Serializable] by default,
+ * so it is not necessary to create custom serializers when the format is not important.
+ * Additionally, [LocalDateTimeIso8601Serializer] is provided for the ISO 8601 format.
+ */
+public abstract class CustomLocalDateTimeSerializer(
+    format: DateTimeFormat<LocalDateTime>,
+) : KSerializer<LocalDateTime> by format.asKSerializer("kotlinx.datetime.LocalDateTime")

--- a/core/common/src/serializers/LocalDateTimeSerializers.kt
+++ b/core/common/src/serializers/LocalDateTimeSerializers.kt
@@ -104,14 +104,23 @@ public object LocalDateTimeComponentSerializer: KSerializer<LocalDateTime> {
  * An abstract serializer for [LocalDateTime] values that uses
  * a custom [DateTimeFormat] to serialize and deserialize the value.
  *
+ * [name] is the name of the serializer.
+ * The [SerialDescriptor.serialName] of the resulting serializer is `kotlinx.datetime.LocalDateTime serializer `[name].
+ * [SerialDescriptor.serialName] must be unique across all serializers in the same serialization context.
+ * When defining a serializer in a library, it is recommended to use the fully qualified class name in [name]
+ * to avoid conflicts with serializers defined by other libraries and client code.
+ *
  * This serializer is abstract and must be subclassed to provide a concrete serializer.
  * Example:
  * ```
- * object PythonDateTimeSerializer : FormattedLocalDateTimeSerializer(LocalDateTime.Format {
- *     date(LocalDate.Formats.ISO)
- *     char(' ')
- *     time(LocalTime.Formats.ISO)
- * })
+ * // serializes LocalDateTime(2020, 1, 4, 12, 30) as the string "2020-01-04 12:30"
+ * object PythonDateTimeSerializer : FormattedLocalDateTimeSerializer("my.package.PythonDateTime",
+ *     LocalDateTime.Format {
+ *         date(LocalDate.Formats.ISO)
+ *         char(' ')
+ *         time(LocalTime.Formats.ISO)
+ *     }
+ * )
  * ```
  *
  * Note that [LocalDateTime] is [kotlinx.serialization.Serializable] by default,
@@ -119,5 +128,5 @@ public object LocalDateTimeComponentSerializer: KSerializer<LocalDateTime> {
  * Additionally, [LocalDateTimeIso8601Serializer] is provided for the ISO 8601 format.
  */
 public abstract class FormattedLocalDateTimeSerializer(
-    format: DateTimeFormat<LocalDateTime>,
-) : KSerializer<LocalDateTime> by format.asKSerializer("kotlinx.datetime.LocalDateTime")
+    name: String, format: DateTimeFormat<LocalDateTime>
+) : KSerializer<LocalDateTime> by format.asKSerializer("kotlinx.datetime.LocalDateTime serializer $name")

--- a/core/common/src/serializers/LocalDateTimeSerializers.kt
+++ b/core/common/src/serializers/LocalDateTimeSerializers.kt
@@ -93,7 +93,7 @@ public object LocalDateTimeComponentSerializer: KSerializer<LocalDateTime> {
  * a custom [DateTimeFormat] to serialize and deserialize the value.
  *
  * [name] is the name of the serializer.
- * The [SerialDescriptor.serialName] of the resulting serializer is `kotlinx.datetime.LocalDateTime serializer `[name].
+ * The [SerialDescriptor.serialName] of the resulting serializer is `kotlinx.datetime.LocalDateTime/serializer/`[name].
  * [SerialDescriptor.serialName] must be unique across all serializers in the same serialization context.
  * When defining a serializer in a library, it is recommended to use the fully qualified class name in [name]
  * to avoid conflicts with serializers defined by other libraries and client code.

--- a/core/common/src/serializers/LocalDateTimeSerializers.kt
+++ b/core/common/src/serializers/LocalDateTimeSerializers.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.encoding.*
  * @see LocalDateTime.Formats.ISO
  */
 public object LocalDateTimeIso8601Serializer : KSerializer<LocalDateTime>
-by LocalDateTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDateTime ISO")
+by LocalDateTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDateTime/ISO")
 
 /**
  * A serializer for [LocalDateTime] that represents a value as its components.
@@ -29,7 +29,7 @@ by LocalDateTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalDateTime ISO")
 public object LocalDateTimeComponentSerializer: KSerializer<LocalDateTime> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("kotlinx.datetime.LocalDateTime components") {
+        buildClassSerialDescriptor("kotlinx.datetime.LocalDateTime/components") {
             element<Int>("year")
             element<Short>("month")
             element<Short>("day")
@@ -117,7 +117,7 @@ public object LocalDateTimeComponentSerializer: KSerializer<LocalDateTime> {
  */
 public abstract class FormattedLocalDateTimeSerializer(
     name: String, format: DateTimeFormat<LocalDateTime>
-) : KSerializer<LocalDateTime> by format.asKSerializer("kotlinx.datetime.LocalDateTime serializer $name")
+) : KSerializer<LocalDateTime> by format.asKSerializer("kotlinx.datetime.LocalDateTime/serializer/$name")
 
 /**
  * A serializer for [LocalDateTime] that uses the default [LocalDateTime.toString]/[LocalDateTime.parse].

--- a/core/common/src/serializers/LocalTimeSerializers.kt
+++ b/core/common/src/serializers/LocalTimeSerializers.kt
@@ -90,7 +90,7 @@ public object LocalTimeComponentSerializer : KSerializer<LocalTime> {
  * This serializer is abstract and must be subclassed to provide a concrete serializer.
  * Example:
  * ```
- * object FixedWidthTimeSerializer : CustomLocalTimeSerializer(LocalTime.Format {
+ * object FixedWidthTimeSerializer : FormattedLocalTimeSerializer(LocalTime.Format {
  *     hour(); char(':'); minute(); char(':'); second(); char('.'); secondFraction(3)
  * })
  * ```
@@ -99,6 +99,6 @@ public object LocalTimeComponentSerializer : KSerializer<LocalTime> {
  * so it is not necessary to create custom serializers when the format is not important.
  * Additionally, [LocalTimeIso8601Serializer] is provided for the ISO 8601 format.
  */
-public abstract class CustomLocalTimeSerializer(
+public abstract class FormattedLocalTimeSerializer(
     format: DateTimeFormat<LocalTime>,
 ) : KSerializer<LocalTime> by format.asKSerializer("kotlinx.datetime.LocalTime")

--- a/core/common/src/serializers/LocalTimeSerializers.kt
+++ b/core/common/src/serializers/LocalTimeSerializers.kt
@@ -6,6 +6,7 @@
 package kotlinx.datetime.serializers
 
 import kotlinx.datetime.*
+import kotlinx.datetime.format.DateTimeFormat
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
@@ -81,3 +82,23 @@ public object LocalTimeComponentSerializer : KSerializer<LocalTime> {
         }
     }
 }
+
+/**
+ * An abstract serializer for [LocalTime] values that uses
+ * a custom [DateTimeFormat] to serialize and deserialize the value.
+ *
+ * This serializer is abstract and must be subclassed to provide a concrete serializer.
+ * Example:
+ * ```
+ * object FixedWidthTimeSerializer : CustomLocalTimeSerializer(LocalTime.Format {
+ *     hour(); char(':'); minute(); char(':'); second(); char('.'); secondFraction(3)
+ * })
+ * ```
+ *
+ * Note that [LocalTime] is [kotlinx.serialization.Serializable] by default,
+ * so it is not necessary to create custom serializers when the format is not important.
+ * Additionally, [LocalTimeIso8601Serializer] is provided for the ISO 8601 format.
+ */
+public abstract class CustomLocalTimeSerializer(
+    format: DateTimeFormat<LocalTime>,
+) : KSerializer<LocalTime> by format.asKSerializer("kotlinx.datetime.LocalTime")

--- a/core/common/src/serializers/LocalTimeSerializers.kt
+++ b/core/common/src/serializers/LocalTimeSerializers.kt
@@ -87,10 +87,17 @@ public object LocalTimeComponentSerializer : KSerializer<LocalTime> {
  * An abstract serializer for [LocalTime] values that uses
  * a custom [DateTimeFormat] to serialize and deserialize the value.
  *
+ * [name] is the name of the serializer.
+ * The [SerialDescriptor.serialName] of the resulting serializer is `kotlinx.datetime.LocalTime serializer `[name].
+ * [SerialDescriptor.serialName] must be unique across all serializers in the same serialization context.
+ * When defining a serializer in a library, it is recommended to use the fully qualified class name in [name]
+ * to avoid conflicts with serializers defined by other libraries and client code.
+ *
  * This serializer is abstract and must be subclassed to provide a concrete serializer.
  * Example:
  * ```
- * object FixedWidthTimeSerializer : FormattedLocalTimeSerializer(LocalTime.Format {
+ * // serializes LocalTime(12, 30) as "12:30:00.000"
+ * object FixedWidthTimeSerializer : FormattedLocalTimeSerializer("my.package.FixedWidthTime", LocalTime.Format {
  *     hour(); char(':'); minute(); char(':'); second(); char('.'); secondFraction(3)
  * })
  * ```
@@ -100,5 +107,5 @@ public object LocalTimeComponentSerializer : KSerializer<LocalTime> {
  * Additionally, [LocalTimeIso8601Serializer] is provided for the ISO 8601 format.
  */
 public abstract class FormattedLocalTimeSerializer(
-    format: DateTimeFormat<LocalTime>,
-) : KSerializer<LocalTime> by format.asKSerializer("kotlinx.datetime.LocalTime")
+    name: String, format: DateTimeFormat<LocalTime>
+) : KSerializer<LocalTime> by format.asKSerializer("kotlinx.datetime.LocalTime serializer $name")

--- a/core/common/src/serializers/LocalTimeSerializers.kt
+++ b/core/common/src/serializers/LocalTimeSerializers.kt
@@ -16,21 +16,10 @@ import kotlinx.serialization.encoding.*
  *
  * JSON example: `"12:01:03.999"`
  *
- * @see LocalDate.parse
- * @see LocalDate.toString
+ * @see LocalTime.Formats.ISO
  */
-public object LocalTimeIso8601Serializer : KSerializer<LocalTime> {
-
-    override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("kotlinx.datetime.LocalTime", PrimitiveKind.STRING)
-
-    override fun deserialize(decoder: Decoder): LocalTime =
-        LocalTime.parse(decoder.decodeString())
-
-    override fun serialize(encoder: Encoder, value: LocalTime) {
-        encoder.encodeString(value.toString())
-    }
-}
+public object LocalTimeIso8601Serializer : KSerializer<LocalTime>
+by LocalTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalTime")
 
 /**
  * A serializer for [LocalTime] that represents a value as its components.
@@ -109,3 +98,25 @@ public object LocalTimeComponentSerializer : KSerializer<LocalTime> {
 public abstract class FormattedLocalTimeSerializer(
     name: String, format: DateTimeFormat<LocalTime>
 ) : KSerializer<LocalTime> by format.asKSerializer("kotlinx.datetime.LocalTime serializer $name")
+
+/**
+ * A serializer for [LocalTime] that uses the ISO 8601 representation.
+ *
+ * JSON example: `"12:01:03.999"`
+ *
+ * @see LocalDate.parse
+ * @see LocalDate.toString
+ */
+@PublishedApi
+internal object LocalTimeSerializer : KSerializer<LocalTime> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("kotlinx.datetime.LocalTime", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): LocalTime =
+        LocalTime.parse(decoder.decodeString())
+
+    override fun serialize(encoder: Encoder, value: LocalTime) {
+        encoder.encodeString(value.toString())
+    }
+}

--- a/core/common/src/serializers/LocalTimeSerializers.kt
+++ b/core/common/src/serializers/LocalTimeSerializers.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.encoding.*
  * @see LocalTime.Formats.ISO
  */
 public object LocalTimeIso8601Serializer : KSerializer<LocalTime>
-by LocalTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalTime")
+by LocalTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalTime ISO")
 
 /**
  * A serializer for [LocalTime] that represents a value as its components.
@@ -29,7 +29,7 @@ by LocalTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalTime")
 public object LocalTimeComponentSerializer : KSerializer<LocalTime> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("kotlinx.datetime.LocalTime") {
+        buildClassSerialDescriptor("kotlinx.datetime.LocalTime components") {
             element<Short>("hour")
             element<Short>("minute")
             element<Short>("second", isOptional = true)

--- a/core/common/src/serializers/LocalTimeSerializers.kt
+++ b/core/common/src/serializers/LocalTimeSerializers.kt
@@ -77,7 +77,7 @@ public object LocalTimeComponentSerializer : KSerializer<LocalTime> {
  * a custom [DateTimeFormat] to serialize and deserialize the value.
  *
  * [name] is the name of the serializer.
- * The [SerialDescriptor.serialName] of the resulting serializer is `kotlinx.datetime.LocalTime serializer `[name].
+ * The [SerialDescriptor.serialName] of the resulting serializer is `kotlinx.datetime.LocalTime/serializer/`[name].
  * [SerialDescriptor.serialName] must be unique across all serializers in the same serialization context.
  * When defining a serializer in a library, it is recommended to use the fully qualified class name in [name]
  * to avoid conflicts with serializers defined by other libraries and client code.

--- a/core/common/src/serializers/LocalTimeSerializers.kt
+++ b/core/common/src/serializers/LocalTimeSerializers.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.encoding.*
  * @see LocalTime.Formats.ISO
  */
 public object LocalTimeIso8601Serializer : KSerializer<LocalTime>
-by LocalTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalTime ISO")
+by LocalTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalTime/ISO")
 
 /**
  * A serializer for [LocalTime] that represents a value as its components.
@@ -29,7 +29,7 @@ by LocalTime.Formats.ISO.asKSerializer("kotlinx.datetime.LocalTime ISO")
 public object LocalTimeComponentSerializer : KSerializer<LocalTime> {
 
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("kotlinx.datetime.LocalTime components") {
+        buildClassSerialDescriptor("kotlinx.datetime.LocalTime/components") {
             element<Short>("hour")
             element<Short>("minute")
             element<Short>("second", isOptional = true)
@@ -97,7 +97,7 @@ public object LocalTimeComponentSerializer : KSerializer<LocalTime> {
  */
 public abstract class FormattedLocalTimeSerializer(
     name: String, format: DateTimeFormat<LocalTime>
-) : KSerializer<LocalTime> by format.asKSerializer("kotlinx.datetime.LocalTime serializer $name")
+) : KSerializer<LocalTime> by format.asKSerializer("kotlinx.datetime.LocalTime/serializer/$name")
 
 /**
  * A serializer for [LocalTime] that uses the ISO 8601 representation.

--- a/core/common/src/serializers/TimeZoneSerializers.kt
+++ b/core/common/src/serializers/TimeZoneSerializers.kt
@@ -81,13 +81,13 @@ public object UtcOffsetSerializer: KSerializer<UtcOffset> {
  * This serializer is abstract and must be subclassed to provide a concrete serializer.
  * Example:
  * ```
- * object FourDigitOffsetSerializer : CustomUtcOffsetSerializer(UtcOffset.Formats.FOUR_DIGITS)
+ * object FourDigitOffsetSerializer : FormattedUtcOffsetSerializer(UtcOffset.Formats.FOUR_DIGITS)
  * ```
  *
  * Note that [UtcOffset] is [kotlinx.serialization.Serializable] by default,
  * so it is not necessary to create custom serializers when the format is not important.
  * Additionally, [UtcOffsetSerializer] is provided for the ISO 8601 format.
  */
-public abstract class CustomUtcOffsetSerializer(
+public abstract class FormattedUtcOffsetSerializer(
     format: DateTimeFormat<UtcOffset>,
 ) : KSerializer<UtcOffset> by format.asKSerializer("kotlinx.datetime.UtcOffset")

--- a/core/common/src/serializers/TimeZoneSerializers.kt
+++ b/core/common/src/serializers/TimeZoneSerializers.kt
@@ -57,9 +57,17 @@ public object FixedOffsetTimeZoneSerializer: KSerializer<FixedOffsetTimeZone> {
  *
  * JSON example: `"+02:00"`
  *
- * @see UtcOffset.parse
- * @see UtcOffset.toString
+ * @see UtcOffset.Formats.ISO
  */
+public object UtcOffsetIso8601Serializer : KSerializer<UtcOffset>
+by UtcOffset.Formats.ISO.asKSerializer("kotlinx.datetime.UtcOffset")
+
+/**
+ * A serializer for [UtcOffset] that uses the default [UtcOffset.toString]/[UtcOffset.parse].
+ *
+ * JSON example: `"+02:00"`
+ */
+@Deprecated("Use UtcOffset.serializer() instead", ReplaceWith("UtcOffset.serializer()"))
 public object UtcOffsetSerializer: KSerializer<UtcOffset> {
 
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("kotlinx.datetime.UtcOffset", PrimitiveKind.STRING)

--- a/core/common/src/serializers/TimeZoneSerializers.kt
+++ b/core/common/src/serializers/TimeZoneSerializers.kt
@@ -78,10 +78,19 @@ public object UtcOffsetSerializer: KSerializer<UtcOffset> {
  * An abstract serializer for [UtcOffset] values that uses
  * a custom [DateTimeFormat] to serialize and deserialize the value.
  *
+ * [name] is the name of the serializer.
+ * The [SerialDescriptor.serialName] of the resulting serializer is `kotlinx.datetime.UtcOffset serializer `[name].
+ * [SerialDescriptor.serialName] must be unique across all serializers in the same serialization context.
+ * When defining a serializer in a library, it is recommended to use the fully qualified class name in [name]
+ * to avoid conflicts with serializers defined by other libraries and client code.
+ *
  * This serializer is abstract and must be subclassed to provide a concrete serializer.
  * Example:
  * ```
- * object FourDigitOffsetSerializer : FormattedUtcOffsetSerializer(UtcOffset.Formats.FOUR_DIGITS)
+ * // serializes the UTC offset UtcOffset(hours = 2) as the string "+0200"
+ * object FourDigitOffsetSerializer : FormattedUtcOffsetSerializer(
+ *     "my.package.FOUR_DIGITS", UtcOffset.Formats.FOUR_DIGITS
+ * )
  * ```
  *
  * Note that [UtcOffset] is [kotlinx.serialization.Serializable] by default,
@@ -89,5 +98,5 @@ public object UtcOffsetSerializer: KSerializer<UtcOffset> {
  * Additionally, [UtcOffsetSerializer] is provided for the ISO 8601 format.
  */
 public abstract class FormattedUtcOffsetSerializer(
-    format: DateTimeFormat<UtcOffset>,
-) : KSerializer<UtcOffset> by format.asKSerializer("kotlinx.datetime.UtcOffset")
+    name: String, format: DateTimeFormat<UtcOffset>
+) : KSerializer<UtcOffset> by format.asKSerializer("kotlinx.datetime.UtcOffset serializer $name")

--- a/core/common/src/serializers/TimeZoneSerializers.kt
+++ b/core/common/src/serializers/TimeZoneSerializers.kt
@@ -5,9 +5,8 @@
 
 package kotlinx.datetime.serializers
 
-import kotlinx.datetime.FixedOffsetTimeZone
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.UtcOffset
+import kotlinx.datetime.*
+import kotlinx.datetime.format.DateTimeFormat
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
@@ -74,3 +73,21 @@ public object UtcOffsetSerializer: KSerializer<UtcOffset> {
     }
 
 }
+
+/**
+ * An abstract serializer for [UtcOffset] values that uses
+ * a custom [DateTimeFormat] to serialize and deserialize the value.
+ *
+ * This serializer is abstract and must be subclassed to provide a concrete serializer.
+ * Example:
+ * ```
+ * object FourDigitOffsetSerializer : CustomUtcOffsetSerializer(UtcOffset.Formats.FOUR_DIGITS)
+ * ```
+ *
+ * Note that [UtcOffset] is [kotlinx.serialization.Serializable] by default,
+ * so it is not necessary to create custom serializers when the format is not important.
+ * Additionally, [UtcOffsetSerializer] is provided for the ISO 8601 format.
+ */
+public abstract class CustomUtcOffsetSerializer(
+    format: DateTimeFormat<UtcOffset>,
+) : KSerializer<UtcOffset> by format.asKSerializer("kotlinx.datetime.UtcOffset")

--- a/core/common/src/serializers/TimeZoneSerializers.kt
+++ b/core/common/src/serializers/TimeZoneSerializers.kt
@@ -60,7 +60,7 @@ public object FixedOffsetTimeZoneSerializer: KSerializer<FixedOffsetTimeZone> {
  * @see UtcOffset.Formats.ISO
  */
 public object UtcOffsetIso8601Serializer : KSerializer<UtcOffset>
-by UtcOffset.Formats.ISO.asKSerializer("kotlinx.datetime.UtcOffset")
+by UtcOffset.Formats.ISO.asKSerializer("kotlinx.datetime.UtcOffset ISO")
 
 /**
  * A serializer for [UtcOffset] that uses the default [UtcOffset.toString]/[UtcOffset.parse].

--- a/core/common/src/serializers/TimeZoneSerializers.kt
+++ b/core/common/src/serializers/TimeZoneSerializers.kt
@@ -87,7 +87,7 @@ public object UtcOffsetSerializer: KSerializer<UtcOffset> {
  * a custom [DateTimeFormat] to serialize and deserialize the value.
  *
  * [name] is the name of the serializer.
- * The [SerialDescriptor.serialName] of the resulting serializer is `kotlinx.datetime.UtcOffset serializer `[name].
+ * The [SerialDescriptor.serialName] of the resulting serializer is `kotlinx.datetime.UtcOffset/serializer/`[name].
  * [SerialDescriptor.serialName] must be unique across all serializers in the same serialization context.
  * When defining a serializer in a library, it is recommended to use the fully qualified class name in [name]
  * to avoid conflicts with serializers defined by other libraries and client code.

--- a/core/common/src/serializers/TimeZoneSerializers.kt
+++ b/core/common/src/serializers/TimeZoneSerializers.kt
@@ -60,7 +60,7 @@ public object FixedOffsetTimeZoneSerializer: KSerializer<FixedOffsetTimeZone> {
  * @see UtcOffset.Formats.ISO
  */
 public object UtcOffsetIso8601Serializer : KSerializer<UtcOffset>
-by UtcOffset.Formats.ISO.asKSerializer("kotlinx.datetime.UtcOffset ISO")
+by UtcOffset.Formats.ISO.asKSerializer("kotlinx.datetime.UtcOffset/ISO")
 
 /**
  * A serializer for [UtcOffset] that uses the default [UtcOffset.toString]/[UtcOffset.parse].
@@ -107,4 +107,4 @@ public object UtcOffsetSerializer: KSerializer<UtcOffset> {
  */
 public abstract class FormattedUtcOffsetSerializer(
     name: String, format: DateTimeFormat<UtcOffset>
-) : KSerializer<UtcOffset> by format.asKSerializer("kotlinx.datetime.UtcOffset serializer $name")
+) : KSerializer<UtcOffset> by format.asKSerializer("kotlinx.datetime.UtcOffset/serializer/$name")

--- a/core/commonKotlin/src/Instant.kt
+++ b/core/commonKotlin/src/Instant.kt
@@ -10,7 +10,7 @@ package kotlinx.datetime
 
 import kotlinx.datetime.format.*
 import kotlinx.datetime.internal.*
-import kotlinx.datetime.serializers.InstantIso8601Serializer
+import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 import kotlin.time.*
 import kotlin.time.Duration.Companion.nanoseconds
@@ -26,7 +26,7 @@ private const val MIN_SECOND = -31557014167219200L // -1000000000-01-01T00:00:00
  */
 private const val MAX_SECOND = 31556889864403199L // +1000000000-12-31T23:59:59
 
-@Serializable(with = InstantIso8601Serializer::class)
+@Serializable(with = InstantSerializer::class)
 public actual class Instant internal constructor(public actual val epochSeconds: Long, public actual val nanosecondsOfSecond: Int) : Comparable<Instant> {
 
     init {

--- a/core/commonKotlin/src/LocalDate.kt
+++ b/core/commonKotlin/src/LocalDate.kt
@@ -12,7 +12,7 @@ import kotlinx.datetime.format.*
 import kotlinx.datetime.internal.*
 import kotlinx.datetime.internal.safeAdd
 import kotlinx.datetime.internal.safeMultiply
-import kotlinx.datetime.serializers.LocalDateIso8601Serializer
+import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 import kotlin.math.*
 
@@ -22,7 +22,7 @@ internal const val YEAR_MAX = 999_999_999
 private fun isValidYear(year: Int): Boolean =
     year >= YEAR_MIN && year <= YEAR_MAX
 
-@Serializable(with = LocalDateIso8601Serializer::class)
+@Serializable(with = LocalDateSerializer::class)
 public actual class LocalDate actual constructor(public actual val year: Int, month: Int, public actual val day: Int) : Comparable<LocalDate> {
 
     private val _month: Int = month

--- a/core/commonKotlin/src/LocalDateTime.kt
+++ b/core/commonKotlin/src/LocalDateTime.kt
@@ -13,7 +13,7 @@ import kotlinx.datetime.internal.*
 import kotlinx.datetime.serializers.*
 import kotlinx.serialization.*
 
-@Serializable(with = LocalDateTimeIso8601Serializer::class)
+@Serializable(with = LocalDateTimeSerializer::class)
 public actual class LocalDateTime
 public actual constructor(public actual val date: LocalDate, public actual val time: LocalTime) : Comparable<LocalDateTime> {
     public actual companion object {

--- a/core/commonKotlin/src/LocalTime.kt
+++ b/core/commonKotlin/src/LocalTime.kt
@@ -10,10 +10,10 @@ package kotlinx.datetime
 
 import kotlinx.datetime.internal.*
 import kotlinx.datetime.format.*
-import kotlinx.datetime.serializers.LocalTimeIso8601Serializer
+import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 
-@Serializable(LocalTimeIso8601Serializer::class)
+@Serializable(LocalTimeSerializer::class)
 public actual class LocalTime actual constructor(
     public actual val hour: Int,
     public actual val minute: Int,

--- a/core/commonKotlin/src/UtcOffset.kt
+++ b/core/commonKotlin/src/UtcOffset.kt
@@ -7,11 +7,12 @@ package kotlinx.datetime
 
 import kotlinx.datetime.internal.*
 import kotlinx.datetime.format.*
-import kotlinx.datetime.serializers.UtcOffsetSerializer
+import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 import kotlin.math.abs
 import kotlin.native.concurrent.ThreadLocal
 
+@Suppress("DEPRECATION")
 @Serializable(with = UtcOffsetSerializer::class)
 public actual class UtcOffset private constructor(public actual val totalSeconds: Int) {
 

--- a/core/jvm/src/Instant.kt
+++ b/core/jvm/src/Instant.kt
@@ -9,7 +9,7 @@ package kotlinx.datetime
 import kotlinx.datetime.format.*
 import kotlinx.datetime.internal.safeMultiply
 import kotlinx.datetime.internal.*
-import kotlinx.datetime.serializers.InstantIso8601Serializer
+import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 import java.time.DateTimeException
 import java.time.temporal.*
@@ -19,7 +19,7 @@ import kotlin.time.Duration.Companion.seconds
 import java.time.Instant as jtInstant
 import java.time.Clock as jtClock
 
-@Serializable(with = InstantIso8601Serializer::class)
+@Serializable(with = InstantSerializer::class)
 public actual class Instant internal constructor(
     internal val value: jtInstant
 ) : Comparable<Instant> {

--- a/core/jvm/src/LocalDate.kt
+++ b/core/jvm/src/LocalDate.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.format.*
 import kotlinx.datetime.internal.safeAdd
 import kotlinx.datetime.internal.safeMultiply
 import kotlinx.datetime.internal.*
-import kotlinx.datetime.serializers.LocalDateIso8601Serializer
+import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 import java.time.DateTimeException
 import java.time.format.DateTimeParseException
@@ -17,7 +17,7 @@ import java.time.temporal.ChronoUnit
 import java.time.LocalDate as jtLocalDate
 import kotlin.internal.*
 
-@Serializable(with = LocalDateIso8601Serializer::class)
+@Serializable(with = LocalDateSerializer::class)
 public actual class LocalDate internal constructor(
     internal val value: jtLocalDate
 ) : Comparable<LocalDate>, java.io.Serializable {

--- a/core/jvm/src/LocalDateTimeJvm.kt
+++ b/core/jvm/src/LocalDateTimeJvm.kt
@@ -8,13 +8,13 @@ package kotlinx.datetime
 
 import kotlinx.datetime.format.*
 import kotlinx.datetime.internal.removeLeadingZerosFromLongYearFormLocalDateTime
-import kotlinx.datetime.serializers.LocalDateTimeIso8601Serializer
+import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 import java.time.DateTimeException
 import java.time.format.DateTimeParseException
 import java.time.LocalDateTime as jtLocalDateTime
 
-@Serializable(with = LocalDateTimeIso8601Serializer::class)
+@Serializable(with = LocalDateTimeSerializer::class)
 public actual class LocalDateTime internal constructor(
     internal val value: jtLocalDateTime
 ) : Comparable<LocalDateTime>, java.io.Serializable {

--- a/core/jvm/src/LocalTimeJvm.kt
+++ b/core/jvm/src/LocalTimeJvm.kt
@@ -9,13 +9,13 @@ package kotlinx.datetime
 
 import kotlinx.datetime.format.*
 import kotlinx.datetime.internal.*
-import kotlinx.datetime.serializers.LocalTimeIso8601Serializer
+import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 import java.time.DateTimeException
 import java.time.format.DateTimeParseException
 import java.time.LocalTime as jtLocalTime
 
-@Serializable(with = LocalTimeIso8601Serializer::class)
+@Serializable(with = LocalTimeSerializer::class)
 public actual class LocalTime internal constructor(
     internal val value: jtLocalTime
 ) : Comparable<LocalTime>, java.io.Serializable {

--- a/core/jvm/src/UtcOffsetJvm.kt
+++ b/core/jvm/src/UtcOffsetJvm.kt
@@ -6,13 +6,14 @@
 package kotlinx.datetime
 
 import kotlinx.datetime.format.*
-import kotlinx.datetime.serializers.UtcOffsetSerializer
+import kotlinx.datetime.serializers.*
 import kotlinx.serialization.Serializable
 import java.time.DateTimeException
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatterBuilder
 import java.time.format.*
 
+@Suppress("DEPRECATION")
 @Serializable(with = UtcOffsetSerializer::class)
 public actual class UtcOffset(
     internal val zoneOffset: ZoneOffset

--- a/integration-testing/serialization/common/test/DateTimePeriodSerializationTest.kt
+++ b/integration-testing/serialization/common/test/DateTimePeriodSerializationTest.kt
@@ -97,28 +97,34 @@ class DateTimePeriodSerializationTest {
 
     @Test
     fun testDatePeriodIso8601Serialization() {
+        assertKSerializerName("kotlinx.datetime.DatePeriod", DatePeriodIso8601Serializer)
         datePeriodIso8601Serialization(DatePeriodIso8601Serializer, DateTimePeriodIso8601Serializer)
     }
 
     @Test
     fun testDatePeriodComponentSerialization() {
+        assertKSerializerName("kotlinx.datetime.DatePeriod", DatePeriodComponentSerializer)
         datePeriodComponentSerialization(DatePeriodComponentSerializer, DateTimePeriodComponentSerializer)
     }
 
     @Test
     fun testDateTimePeriodIso8601Serialization() {
+        assertKSerializerName("kotlinx.datetime.DateTimePeriod", DateTimePeriodIso8601Serializer)
         dateTimePeriodIso8601Serialization(DateTimePeriodIso8601Serializer)
     }
 
     @Test
     fun testDateTimePeriodComponentSerialization() {
+        assertKSerializerName("kotlinx.datetime.DateTimePeriod", DateTimePeriodComponentSerializer)
         dateTimePeriodComponentSerialization(DateTimePeriodComponentSerializer)
     }
 
     @Test
     fun testDefaultSerializers() {
         // Check that they behave the same as the ISO 8601 serializers
+        assertKSerializerName<DateTimePeriod>("kotlinx.datetime.DateTimePeriod", Json.serializersModule.serializer())
         dateTimePeriodIso8601Serialization(Json.serializersModule.serializer())
+        assertKSerializerName<DatePeriod>("kotlinx.datetime.DatePeriod", Json.serializersModule.serializer())
         datePeriodIso8601Serialization(Json.serializersModule.serializer(), Json.serializersModule.serializer())
     }
 

--- a/integration-testing/serialization/common/test/DateTimePeriodSerializationTest.kt
+++ b/integration-testing/serialization/common/test/DateTimePeriodSerializationTest.kt
@@ -97,25 +97,25 @@ class DateTimePeriodSerializationTest {
 
     @Test
     fun testDatePeriodIso8601Serialization() {
-        assertKSerializerName("kotlinx.datetime.DatePeriod", DatePeriodIso8601Serializer)
+        assertKSerializerName("kotlinx.datetime.DatePeriod ISO", DatePeriodIso8601Serializer)
         datePeriodIso8601Serialization(DatePeriodIso8601Serializer, DateTimePeriodIso8601Serializer)
     }
 
     @Test
     fun testDatePeriodComponentSerialization() {
-        assertKSerializerName("kotlinx.datetime.DatePeriod", DatePeriodComponentSerializer)
+        assertKSerializerName("kotlinx.datetime.DatePeriod components", DatePeriodComponentSerializer)
         datePeriodComponentSerialization(DatePeriodComponentSerializer, DateTimePeriodComponentSerializer)
     }
 
     @Test
     fun testDateTimePeriodIso8601Serialization() {
-        assertKSerializerName("kotlinx.datetime.DateTimePeriod", DateTimePeriodIso8601Serializer)
+        assertKSerializerName("kotlinx.datetime.DateTimePeriod ISO", DateTimePeriodIso8601Serializer)
         dateTimePeriodIso8601Serialization(DateTimePeriodIso8601Serializer)
     }
 
     @Test
     fun testDateTimePeriodComponentSerialization() {
-        assertKSerializerName("kotlinx.datetime.DateTimePeriod", DateTimePeriodComponentSerializer)
+        assertKSerializerName("kotlinx.datetime.DateTimePeriod components", DateTimePeriodComponentSerializer)
         dateTimePeriodComponentSerialization(DateTimePeriodComponentSerializer)
     }
 

--- a/integration-testing/serialization/common/test/DateTimePeriodSerializationTest.kt
+++ b/integration-testing/serialization/common/test/DateTimePeriodSerializationTest.kt
@@ -97,25 +97,25 @@ class DateTimePeriodSerializationTest {
 
     @Test
     fun testDatePeriodIso8601Serialization() {
-        assertKSerializerName("kotlinx.datetime.DatePeriod ISO", DatePeriodIso8601Serializer)
+        assertKSerializerName("kotlinx.datetime.DatePeriod/ISO", DatePeriodIso8601Serializer)
         datePeriodIso8601Serialization(DatePeriodIso8601Serializer, DateTimePeriodIso8601Serializer)
     }
 
     @Test
     fun testDatePeriodComponentSerialization() {
-        assertKSerializerName("kotlinx.datetime.DatePeriod components", DatePeriodComponentSerializer)
+        assertKSerializerName("kotlinx.datetime.DatePeriod/components", DatePeriodComponentSerializer)
         datePeriodComponentSerialization(DatePeriodComponentSerializer, DateTimePeriodComponentSerializer)
     }
 
     @Test
     fun testDateTimePeriodIso8601Serialization() {
-        assertKSerializerName("kotlinx.datetime.DateTimePeriod ISO", DateTimePeriodIso8601Serializer)
+        assertKSerializerName("kotlinx.datetime.DateTimePeriod/ISO", DateTimePeriodIso8601Serializer)
         dateTimePeriodIso8601Serialization(DateTimePeriodIso8601Serializer)
     }
 
     @Test
     fun testDateTimePeriodComponentSerialization() {
-        assertKSerializerName("kotlinx.datetime.DateTimePeriod components", DateTimePeriodComponentSerializer)
+        assertKSerializerName("kotlinx.datetime.DateTimePeriod/components", DateTimePeriodComponentSerializer)
         dateTimePeriodComponentSerialization(DateTimePeriodComponentSerializer)
     }
 

--- a/integration-testing/serialization/common/test/DateTimeUnitSerializationTest.kt
+++ b/integration-testing/serialization/common/test/DateTimeUnitSerializationTest.kt
@@ -18,7 +18,7 @@ class DateTimeUnitSerializationTest {
         repeat(100) {
             val nanoseconds = Random.nextLong(1, Long.MAX_VALUE)
             val unit = DateTimeUnit.TimeBased(nanoseconds)
-            val json = "{\"nanoseconds\":${nanoseconds.toString()}}" // https://youtrack.jetbrains.com/issue/KT-39891
+            val json = "{\"nanoseconds\":$nanoseconds}"
             assertEquals(json, Json.encodeToString(serializer, unit))
             assertEquals(unit, Json.decodeFromString(serializer, json))
         }
@@ -65,7 +65,7 @@ class DateTimeUnitSerializationTest {
         repeat(100) {
             val nanoseconds = Random.nextLong(1, Long.MAX_VALUE)
             val unit = DateTimeUnit.TimeBased(nanoseconds)
-            val json = "{\"type\":\"kotlinx.datetime.TimeBased\",\"nanoseconds\":${nanoseconds.toString()}}" // https://youtrack.jetbrains.com/issue/KT-39891
+            val json = "{\"type\":\"kotlinx.datetime.TimeBased\",\"nanoseconds\":$nanoseconds}"
             assertEquals(json, Json.encodeToString(serializer, unit))
             assertEquals(unit, Json.decodeFromString(serializer, json))
         }
@@ -87,21 +87,25 @@ class DateTimeUnitSerializationTest {
 
     @Test
     fun testTimeBasedUnitSerialization() {
+        assertKSerializerName("kotlinx.datetime.TimeBased", TimeBasedDateTimeUnitSerializer)
         timeBasedSerialization(TimeBasedDateTimeUnitSerializer)
     }
 
     @Test
     fun testDayBasedSerialization() {
+        assertKSerializerName("kotlinx.datetime.DayBased", DayBasedDateTimeUnitSerializer)
         dayBasedSerialization(DayBasedDateTimeUnitSerializer)
     }
 
     @Test
     fun testMonthBasedSerialization() {
+        assertKSerializerName("kotlinx.datetime.MonthBased", MonthBasedDateTimeUnitSerializer)
         monthBasedSerialization(MonthBasedDateTimeUnitSerializer)
     }
 
     @Test
     fun testDateBasedSerialization() {
+        assertKSerializerName("kotlinx.datetime.DateTimeUnit.DateBased", DateBasedDateTimeUnitSerializer)
         dateBasedSerialization(DateBasedDateTimeUnitSerializer)
     }
 

--- a/integration-testing/serialization/common/test/DayOfWeekSerializationTest.kt
+++ b/integration-testing/serialization/common/test/DayOfWeekSerializationTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.*
 class DayOfWeekSerializationTest {
     @Test
     fun testSerialization() {
+        assertKSerializerName("kotlinx.datetime.DayOfWeek", DayOfWeekSerializer)
         for (dayOfWeek in DayOfWeek.entries) {
             val json = "\"${dayOfWeek.name}\""
             assertEquals(json, Json.encodeToString(DayOfWeekSerializer, dayOfWeek))

--- a/integration-testing/serialization/common/test/InstantSerializationTest.kt
+++ b/integration-testing/serialization/common/test/InstantSerializationTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.datetime.serialization.test
 
 import kotlinx.datetime.*
+import kotlinx.datetime.format.DateTimeComponents
 import kotlinx.datetime.serializers.*
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
@@ -65,5 +66,26 @@ class InstantSerializationTest {
     fun testDefaultSerializers() {
         // should be the same as the ISO 8601
         iso8601Serialization(Json.serializersModule.serializer())
+    }
+
+    object Rfc1123InstantSerializer : CustomInstantSerializer(DateTimeComponents.Formats.RFC_1123)
+
+    @Test
+    fun testCustomSerializer() {
+        for ((instant, json) in listOf(
+            Pair(Instant.fromEpochSeconds(1607505416),
+                "\"Wed, 9 Dec 2020 09:16:56 GMT\""),
+            Pair(Instant.fromEpochSeconds(-1607505416),
+                "\"Thu, 23 Jan 1919 14:43:04 GMT\""),
+            Pair(Instant.fromEpochSeconds(987654321),
+                "\"Thu, 19 Apr 2001 04:25:21 GMT\""),
+        )) {
+            assertEquals(json, Json.encodeToString(Rfc1123InstantSerializer, instant))
+            assertEquals(instant, Json.decodeFromString(Rfc1123InstantSerializer, json))
+        }
+        assertEquals("\"Thu, 19 Apr 2001 04:25:21 GMT\"",
+            Json.encodeToString(Rfc1123InstantSerializer, Instant.fromEpochSeconds(987654321, 123456789)))
+        assertEquals(Instant.fromEpochSeconds(987654321),
+            Json.decodeFromString(Rfc1123InstantSerializer, "\"Thu, 19 Apr 2001 08:25:21 +0400\""))
     }
 }

--- a/integration-testing/serialization/common/test/InstantSerializationTest.kt
+++ b/integration-testing/serialization/common/test/InstantSerializationTest.kt
@@ -68,10 +68,11 @@ class InstantSerializationTest {
         iso8601Serialization(Json.serializersModule.serializer())
     }
 
-    object Rfc1123InstantSerializer : FormattedInstantSerializer(DateTimeComponents.Formats.RFC_1123)
+    object Rfc1123InstantSerializer : FormattedInstantSerializer("RFC_1123", DateTimeComponents.Formats.RFC_1123)
 
     @Test
     fun testCustomSerializer() {
+        assertKSerializerName("kotlinx.datetime.Instant serializer RFC_1123", Rfc1123InstantSerializer)
         for ((instant, json) in listOf(
             Pair(Instant.fromEpochSeconds(1607505416),
                 "\"Wed, 9 Dec 2020 09:16:56 GMT\""),

--- a/integration-testing/serialization/common/test/InstantSerializationTest.kt
+++ b/integration-testing/serialization/common/test/InstantSerializationTest.kt
@@ -68,7 +68,7 @@ class InstantSerializationTest {
         iso8601Serialization(Json.serializersModule.serializer())
     }
 
-    object Rfc1123InstantSerializer : CustomInstantSerializer(DateTimeComponents.Formats.RFC_1123)
+    object Rfc1123InstantSerializer : FormattedInstantSerializer(DateTimeComponents.Formats.RFC_1123)
 
     @Test
     fun testCustomSerializer() {

--- a/integration-testing/serialization/common/test/InstantSerializationTest.kt
+++ b/integration-testing/serialization/common/test/InstantSerializationTest.kt
@@ -70,13 +70,13 @@ class InstantSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
-        assertKSerializerName("kotlinx.datetime.Instant", InstantIso8601Serializer)
+        assertKSerializerName("kotlinx.datetime.Instant ISO", InstantIso8601Serializer)
         iso8601Serialization(InstantIso8601Serializer)
     }
 
     @Test
     fun testComponentSerialization() {
-        assertKSerializerName("kotlinx.datetime.Instant", InstantComponentSerializer)
+        assertKSerializerName("kotlinx.datetime.Instant components", InstantComponentSerializer)
         componentSerialization(InstantComponentSerializer)
     }
 

--- a/integration-testing/serialization/common/test/InstantSerializationTest.kt
+++ b/integration-testing/serialization/common/test/InstantSerializationTest.kt
@@ -15,10 +15,26 @@ class InstantSerializationTest {
 
     private fun iso8601Serialization(serializer: KSerializer<Instant>) {
         for ((instant, json) in listOf(
-            Pair(Instant.fromEpochSeconds(1607505416, 124000),
-                "\"2020-12-09T09:16:56.000124Z\""),
-            Pair(Instant.fromEpochSeconds(-1607505416, -124000),
-                "\"1919-01-23T14:43:03.999876Z\""),
+            Pair(Instant.fromEpochSeconds(1607505416, 120000),
+                "\"2020-12-09T09:16:56.00012Z\""),
+            Pair(Instant.fromEpochSeconds(-1607505416, -120000),
+                "\"1919-01-23T14:43:03.99988Z\""),
+            Pair(Instant.fromEpochSeconds(987654321, 123456789),
+                "\"2001-04-19T04:25:21.123456789Z\""),
+            Pair(Instant.fromEpochSeconds(987654321, 0),
+                "\"2001-04-19T04:25:21Z\""),
+        )) {
+            assertEquals(json, Json.encodeToString(serializer, instant))
+            assertEquals(instant, Json.decodeFromString(serializer, json))
+        }
+    }
+
+    private fun defaultSerialization(serializer: KSerializer<Instant>) {
+        for ((instant, json) in listOf(
+            Pair(Instant.fromEpochSeconds(1607505416, 120000),
+                "\"2020-12-09T09:16:56.000120Z\""),
+            Pair(Instant.fromEpochSeconds(-1607505416, -120000),
+                "\"1919-01-23T14:43:03.999880Z\""),
             Pair(Instant.fromEpochSeconds(987654321, 123456789),
                 "\"2001-04-19T04:25:21.123456789Z\""),
             Pair(Instant.fromEpochSeconds(987654321, 0),
@@ -68,7 +84,7 @@ class InstantSerializationTest {
     fun testDefaultSerializers() {
         // should be the same as the ISO 8601
         assertKSerializerName<Instant>("kotlinx.datetime.Instant", Json.serializersModule.serializer())
-        iso8601Serialization(Json.serializersModule.serializer())
+        defaultSerialization(Json.serializersModule.serializer())
     }
 
     object Rfc1123InstantSerializer : FormattedInstantSerializer("RFC_1123", DateTimeComponents.Formats.RFC_1123)

--- a/integration-testing/serialization/common/test/InstantSerializationTest.kt
+++ b/integration-testing/serialization/common/test/InstantSerializationTest.kt
@@ -54,17 +54,20 @@ class InstantSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
+        assertKSerializerName("kotlinx.datetime.Instant", InstantIso8601Serializer)
         iso8601Serialization(InstantIso8601Serializer)
     }
 
     @Test
     fun testComponentSerialization() {
+        assertKSerializerName("kotlinx.datetime.Instant", InstantComponentSerializer)
         componentSerialization(InstantComponentSerializer)
     }
 
     @Test
     fun testDefaultSerializers() {
         // should be the same as the ISO 8601
+        assertKSerializerName<Instant>("kotlinx.datetime.Instant", Json.serializersModule.serializer())
         iso8601Serialization(Json.serializersModule.serializer())
     }
 

--- a/integration-testing/serialization/common/test/InstantSerializationTest.kt
+++ b/integration-testing/serialization/common/test/InstantSerializationTest.kt
@@ -70,13 +70,13 @@ class InstantSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
-        assertKSerializerName("kotlinx.datetime.Instant ISO", InstantIso8601Serializer)
+        assertKSerializerName("kotlinx.datetime.Instant/ISO", InstantIso8601Serializer)
         iso8601Serialization(InstantIso8601Serializer)
     }
 
     @Test
     fun testComponentSerialization() {
-        assertKSerializerName("kotlinx.datetime.Instant components", InstantComponentSerializer)
+        assertKSerializerName("kotlinx.datetime.Instant/components", InstantComponentSerializer)
         componentSerialization(InstantComponentSerializer)
     }
 
@@ -91,7 +91,7 @@ class InstantSerializationTest {
 
     @Test
     fun testCustomSerializer() {
-        assertKSerializerName("kotlinx.datetime.Instant serializer RFC_1123", Rfc1123InstantSerializer)
+        assertKSerializerName("kotlinx.datetime.Instant/serializer/RFC_1123", Rfc1123InstantSerializer)
         for ((instant, json) in listOf(
             Pair(Instant.fromEpochSeconds(1607505416),
                 "\"Wed, 9 Dec 2020 09:16:56 GMT\""),

--- a/integration-testing/serialization/common/test/LocalDateSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalDateSerializationTest.kt
@@ -70,4 +70,17 @@ class LocalDateSerializationTest {
         iso8601Serialization(Json.serializersModule.serializer())
     }
 
+    object IsoBasicLocalDateSerializer : CustomLocalDateSerializer(LocalDate.Formats.ISO_BASIC)
+
+    @Test
+    fun testCustomSerializer() {
+        for ((localDate, json) in listOf(
+            Pair(LocalDate(2020, 12, 9), "\"20201209\""),
+            Pair(LocalDate(-2020, 1, 1), "\"-20200101\""),
+            Pair(LocalDate(2019, 10, 1), "\"20191001\""),
+        )) {
+            assertEquals(json, Json.encodeToString(IsoBasicLocalDateSerializer, localDate))
+            assertEquals(localDate, Json.decodeFromString(IsoBasicLocalDateSerializer, json))
+        }
+    }
 }

--- a/integration-testing/serialization/common/test/LocalDateSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalDateSerializationTest.kt
@@ -70,7 +70,7 @@ class LocalDateSerializationTest {
         iso8601Serialization(Json.serializersModule.serializer())
     }
 
-    object IsoBasicLocalDateSerializer : CustomLocalDateSerializer(LocalDate.Formats.ISO_BASIC)
+    object IsoBasicLocalDateSerializer : FormattedLocalDateSerializer(LocalDate.Formats.ISO_BASIC)
 
     @Test
     fun testCustomSerializer() {

--- a/integration-testing/serialization/common/test/LocalDateSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalDateSerializationTest.kt
@@ -56,17 +56,20 @@ class LocalDateSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
+        assertKSerializerName("kotlinx.datetime.LocalDate", LocalDateIso8601Serializer)
         iso8601Serialization(LocalDateIso8601Serializer)
     }
 
     @Test
     fun testComponentSerialization() {
+        assertKSerializerName("kotlinx.datetime.LocalDate", LocalDateComponentSerializer)
         componentSerialization(LocalDateComponentSerializer)
     }
 
     @Test
     fun testDefaultSerializers() {
         // should be the same as the ISO 8601
+        assertKSerializerName<LocalDate>("kotlinx.datetime.LocalDate", Json.serializersModule.serializer())
         iso8601Serialization(Json.serializersModule.serializer())
     }
 

--- a/integration-testing/serialization/common/test/LocalDateSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalDateSerializationTest.kt
@@ -70,10 +70,11 @@ class LocalDateSerializationTest {
         iso8601Serialization(Json.serializersModule.serializer())
     }
 
-    object IsoBasicLocalDateSerializer : FormattedLocalDateSerializer(LocalDate.Formats.ISO_BASIC)
+    object IsoBasicLocalDateSerializer : FormattedLocalDateSerializer("ISO_BASIC", LocalDate.Formats.ISO_BASIC)
 
     @Test
     fun testCustomSerializer() {
+        assertKSerializerName("kotlinx.datetime.LocalDate serializer ISO_BASIC", IsoBasicLocalDateSerializer)
         for ((localDate, json) in listOf(
             Pair(LocalDate(2020, 12, 9), "\"20201209\""),
             Pair(LocalDate(-2020, 1, 1), "\"-20200101\""),
@@ -83,4 +84,9 @@ class LocalDateSerializationTest {
             assertEquals(localDate, Json.decodeFromString(IsoBasicLocalDateSerializer, json))
         }
     }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+fun <T> assertKSerializerName(expectedName: String, serializer: KSerializer<T>) {
+    assertEquals(expectedName, serializer.descriptor.serialName)
 }

--- a/integration-testing/serialization/common/test/LocalDateSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalDateSerializationTest.kt
@@ -56,13 +56,13 @@ class LocalDateSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
-        assertKSerializerName("kotlinx.datetime.LocalDate", LocalDateIso8601Serializer)
+        assertKSerializerName("kotlinx.datetime.LocalDate ISO", LocalDateIso8601Serializer)
         iso8601Serialization(LocalDateIso8601Serializer)
     }
 
     @Test
     fun testComponentSerialization() {
-        assertKSerializerName("kotlinx.datetime.LocalDate", LocalDateComponentSerializer)
+        assertKSerializerName("kotlinx.datetime.LocalDate components", LocalDateComponentSerializer)
         componentSerialization(LocalDateComponentSerializer)
     }
 

--- a/integration-testing/serialization/common/test/LocalDateSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalDateSerializationTest.kt
@@ -56,13 +56,13 @@ class LocalDateSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
-        assertKSerializerName("kotlinx.datetime.LocalDate ISO", LocalDateIso8601Serializer)
+        assertKSerializerName("kotlinx.datetime.LocalDate/ISO", LocalDateIso8601Serializer)
         iso8601Serialization(LocalDateIso8601Serializer)
     }
 
     @Test
     fun testComponentSerialization() {
-        assertKSerializerName("kotlinx.datetime.LocalDate components", LocalDateComponentSerializer)
+        assertKSerializerName("kotlinx.datetime.LocalDate/components", LocalDateComponentSerializer)
         componentSerialization(LocalDateComponentSerializer)
     }
 
@@ -77,7 +77,7 @@ class LocalDateSerializationTest {
 
     @Test
     fun testCustomSerializer() {
-        assertKSerializerName("kotlinx.datetime.LocalDate serializer ISO_BASIC", IsoBasicLocalDateSerializer)
+        assertKSerializerName("kotlinx.datetime.LocalDate/serializer/ISO_BASIC", IsoBasicLocalDateSerializer)
         for ((localDate, json) in listOf(
             Pair(LocalDate(2020, 12, 9), "\"20201209\""),
             Pair(LocalDate(-2020, 1, 1), "\"-20200101\""),

--- a/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
@@ -84,7 +84,7 @@ class LocalDateTimeSerializationTest {
         iso8601Serialization(Json.serializersModule.serializer())
     }
 
-    object PythonDateTimeSerializer : FormattedLocalDateTimeSerializer(LocalDateTime.Format {
+    object PythonDateTimeSerializer : FormattedLocalDateTimeSerializer("PythonDateTime", LocalDateTime.Format {
         date(LocalDate.Formats.ISO)
         char(' ')
         time(LocalTime.Formats.ISO)
@@ -92,6 +92,7 @@ class LocalDateTimeSerializationTest {
 
     @Test
     fun testCustomSerializer() {
+        assertKSerializerName("kotlinx.datetime.LocalDateTime serializer PythonDateTime", PythonDateTimeSerializer)
         for ((localDateTime, json) in listOf(
             Pair(LocalDateTime(2008, 7, 5, 2, 1), "\"2008-07-05 02:01:00\""),
             Pair(LocalDateTime(2007, 12, 31, 23, 59, 1), "\"2007-12-31 23:59:01\""),

--- a/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
@@ -70,17 +70,20 @@ class LocalDateTimeSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
+        assertKSerializerName<LocalDateTime>("kotlinx.datetime.LocalDateTime", LocalDateTimeComponentSerializer)
         iso8601Serialization(LocalDateTimeIso8601Serializer)
     }
 
     @Test
     fun testComponentSerialization() {
+        assertKSerializerName<LocalDateTime>("kotlinx.datetime.LocalDateTime", LocalDateTimeComponentSerializer)
         componentSerialization(LocalDateTimeComponentSerializer)
     }
 
     @Test
     fun testDefaultSerializers() {
         // should be the same as the ISO 8601
+        assertKSerializerName<LocalDateTime>("kotlinx.datetime.LocalDateTime", Json.serializersModule.serializer())
         iso8601Serialization(Json.serializersModule.serializer())
     }
 

--- a/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
@@ -6,6 +6,7 @@
 package kotlinx.datetime.serialization.test
 
 import kotlinx.datetime.*
+import kotlinx.datetime.format.char
 import kotlinx.datetime.serializers.*
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.*
@@ -81,5 +82,25 @@ class LocalDateTimeSerializationTest {
     fun testDefaultSerializers() {
         // should be the same as the ISO 8601
         iso8601Serialization(Json.serializersModule.serializer())
+    }
+
+    object PythonDateTimeSerializer : CustomLocalDateTimeSerializer(LocalDateTime.Format {
+        date(LocalDate.Formats.ISO)
+        char(' ')
+        time(LocalTime.Formats.ISO)
+    })
+
+    @Test
+    fun testCustomSerializer() {
+        for ((localDateTime, json) in listOf(
+            Pair(LocalDateTime(2008, 7, 5, 2, 1), "\"2008-07-05 02:01:00\""),
+            Pair(LocalDateTime(2007, 12, 31, 23, 59, 1), "\"2007-12-31 23:59:01\""),
+            Pair(LocalDateTime(999, 12, 31, 23, 59, 59, 990000000), "\"0999-12-31 23:59:59.99\""),
+            Pair(LocalDateTime(-1, 1, 2, 23, 59, 59, 999990000), "\"-0001-01-02 23:59:59.99999\""),
+            Pair(LocalDateTime(-2008, 1, 2, 23, 59, 59, 999999990), "\"-2008-01-02 23:59:59.99999999\""),
+        )) {
+            assertEquals(json, Json.encodeToString(PythonDateTimeSerializer, localDateTime))
+            assertEquals(localDateTime, Json.decodeFromString(PythonDateTimeSerializer, json))
+        }
     }
 }

--- a/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
@@ -83,13 +83,15 @@ class LocalDateTimeSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
-        assertKSerializerName<LocalDateTime>("kotlinx.datetime.LocalDateTime", LocalDateTimeComponentSerializer)
+        assertKSerializerName<LocalDateTime>("kotlinx.datetime.LocalDateTime ISO", LocalDateTimeIso8601Serializer)
         iso8601Serialization(LocalDateTimeIso8601Serializer)
     }
 
     @Test
     fun testComponentSerialization() {
-        assertKSerializerName<LocalDateTime>("kotlinx.datetime.LocalDateTime", LocalDateTimeComponentSerializer)
+        assertKSerializerName<LocalDateTime>(
+            "kotlinx.datetime.LocalDateTime components", LocalDateTimeComponentSerializer
+        )
         componentSerialization(LocalDateTimeComponentSerializer)
     }
 

--- a/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
@@ -16,6 +16,19 @@ import kotlin.test.*
 class LocalDateTimeSerializationTest {
     private fun iso8601Serialization(serializer: KSerializer<LocalDateTime>) {
         for ((localDateTime, json) in listOf(
+            Pair(LocalDateTime(2008, 7, 5, 2, 1), "\"2008-07-05T02:01:00\""),
+            Pair(LocalDateTime(2007, 12, 31, 23, 59, 1), "\"2007-12-31T23:59:01\""),
+            Pair(LocalDateTime(999, 12, 31, 23, 59, 59, 990000000), "\"0999-12-31T23:59:59.99\""),
+            Pair(LocalDateTime(-1, 1, 2, 23, 59, 59, 999990000), "\"-0001-01-02T23:59:59.99999\""),
+            Pair(LocalDateTime(-2008, 1, 2, 23, 59, 59, 999999990), "\"-2008-01-02T23:59:59.99999999\""),
+        )) {
+            assertEquals(json, Json.encodeToString(serializer, localDateTime))
+            assertEquals(localDateTime, Json.decodeFromString(serializer, json))
+        }
+    }
+
+    private fun defaultSerialization(serializer: KSerializer<LocalDateTime>) {
+        for ((localDateTime, json) in listOf(
             Pair(LocalDateTime(2008, 7, 5, 2, 1), "\"2008-07-05T02:01\""),
             Pair(LocalDateTime(2007, 12, 31, 23, 59, 1), "\"2007-12-31T23:59:01\""),
             Pair(LocalDateTime(999, 12, 31, 23, 59, 59, 990000000), "\"0999-12-31T23:59:59.990\""),
@@ -84,7 +97,7 @@ class LocalDateTimeSerializationTest {
     fun testDefaultSerializers() {
         // should be the same as the ISO 8601
         assertKSerializerName<LocalDateTime>("kotlinx.datetime.LocalDateTime", Json.serializersModule.serializer())
-        iso8601Serialization(Json.serializersModule.serializer())
+        defaultSerialization(Json.serializersModule.serializer())
     }
 
     object PythonDateTimeSerializer : FormattedLocalDateTimeSerializer("PythonDateTime", LocalDateTime.Format {

--- a/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
@@ -84,7 +84,7 @@ class LocalDateTimeSerializationTest {
         iso8601Serialization(Json.serializersModule.serializer())
     }
 
-    object PythonDateTimeSerializer : CustomLocalDateTimeSerializer(LocalDateTime.Format {
+    object PythonDateTimeSerializer : FormattedLocalDateTimeSerializer(LocalDateTime.Format {
         date(LocalDate.Formats.ISO)
         char(' ')
         time(LocalTime.Formats.ISO)

--- a/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalDateTimeSerializationTest.kt
@@ -83,14 +83,14 @@ class LocalDateTimeSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
-        assertKSerializerName<LocalDateTime>("kotlinx.datetime.LocalDateTime ISO", LocalDateTimeIso8601Serializer)
+        assertKSerializerName<LocalDateTime>("kotlinx.datetime.LocalDateTime/ISO", LocalDateTimeIso8601Serializer)
         iso8601Serialization(LocalDateTimeIso8601Serializer)
     }
 
     @Test
     fun testComponentSerialization() {
         assertKSerializerName<LocalDateTime>(
-            "kotlinx.datetime.LocalDateTime components", LocalDateTimeComponentSerializer
+            "kotlinx.datetime.LocalDateTime/components", LocalDateTimeComponentSerializer
         )
         componentSerialization(LocalDateTimeComponentSerializer)
     }
@@ -110,7 +110,7 @@ class LocalDateTimeSerializationTest {
 
     @Test
     fun testCustomSerializer() {
-        assertKSerializerName("kotlinx.datetime.LocalDateTime serializer PythonDateTime", PythonDateTimeSerializer)
+        assertKSerializerName("kotlinx.datetime.LocalDateTime/serializer/PythonDateTime", PythonDateTimeSerializer)
         for ((localDateTime, json) in listOf(
             Pair(LocalDateTime(2008, 7, 5, 2, 1), "\"2008-07-05 02:01:00\""),
             Pair(LocalDateTime(2007, 12, 31, 23, 59, 1), "\"2007-12-31 23:59:01\""),

--- a/integration-testing/serialization/common/test/LocalTimeSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalTimeSerializationTest.kt
@@ -73,13 +73,13 @@ class LocalTimeSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
-        assertKSerializerName("kotlinx.datetime.LocalTime", LocalTimeIso8601Serializer)
+        assertKSerializerName("kotlinx.datetime.LocalTime ISO", LocalTimeIso8601Serializer)
         iso8601Serialization(LocalTimeIso8601Serializer)
     }
 
     @Test
     fun testComponentSerialization() {
-        assertKSerializerName("kotlinx.datetime.LocalTime", LocalTimeComponentSerializer)
+        assertKSerializerName("kotlinx.datetime.LocalTime components", LocalTimeComponentSerializer)
         componentSerialization(LocalTimeComponentSerializer)
     }
 

--- a/integration-testing/serialization/common/test/LocalTimeSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalTimeSerializationTest.kt
@@ -16,6 +16,19 @@ import kotlin.test.*
 class LocalTimeSerializationTest {
     private fun iso8601Serialization(serializer: KSerializer<LocalTime>) {
         for ((localTime, json) in listOf(
+            Pair(LocalTime(2, 1), "\"02:01:00\""),
+            Pair(LocalTime(23, 59, 1), "\"23:59:01\""),
+            Pair(LocalTime(23, 59, 59, 990000000), "\"23:59:59.99\""),
+            Pair(LocalTime(23, 59, 59, 999990000), "\"23:59:59.99999\""),
+            Pair(LocalTime(23, 59, 59, 999999990), "\"23:59:59.99999999\""),
+        )) {
+            assertEquals(json, Json.encodeToString(serializer, localTime))
+            assertEquals(localTime, Json.decodeFromString(serializer, json))
+        }
+    }
+
+    private fun defaultSerialization(serializer: KSerializer<LocalTime>) {
+        for ((localTime, json) in listOf(
             Pair(LocalTime(2, 1), "\"02:01\""),
             Pair(LocalTime(23, 59, 1), "\"23:59:01\""),
             Pair(LocalTime(23, 59, 59, 990000000), "\"23:59:59.990\""),
@@ -72,9 +85,8 @@ class LocalTimeSerializationTest {
 
     @Test
     fun testDefaultSerializers() {
-        // should be the same as the ISO 8601
         assertKSerializerName<LocalTime>("kotlinx.datetime.LocalTime", Json.serializersModule.serializer())
-        iso8601Serialization(Json.serializersModule.serializer())
+        defaultSerialization(Json.serializersModule.serializer())
     }
 
     object FixedWidthTimeSerializer : FormattedLocalTimeSerializer("FixedWidth", LocalTime.Format {

--- a/integration-testing/serialization/common/test/LocalTimeSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalTimeSerializationTest.kt
@@ -74,12 +74,13 @@ class LocalTimeSerializationTest {
         iso8601Serialization(Json.serializersModule.serializer())
     }
 
-    object FixedWidthTimeSerializer : FormattedLocalTimeSerializer(LocalTime.Format {
+    object FixedWidthTimeSerializer : FormattedLocalTimeSerializer("FixedWidth", LocalTime.Format {
         hour(); char(':'); minute(); char(':'); second(); char('.'); secondFraction(3)
     })
 
     @Test
     fun testCustomSerializer() {
+        assertKSerializerName("kotlinx.datetime.LocalTime serializer FixedWidth", FixedWidthTimeSerializer)
         for ((localTime, json) in listOf(
             Pair(LocalTime(2, 1), "\"02:01:00.000\""),
             Pair(LocalTime(23, 59, 1), "\"23:59:01.000\""),

--- a/integration-testing/serialization/common/test/LocalTimeSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalTimeSerializationTest.kt
@@ -74,7 +74,7 @@ class LocalTimeSerializationTest {
         iso8601Serialization(Json.serializersModule.serializer())
     }
 
-    object FixedWidthTimeSerializer : CustomLocalTimeSerializer(LocalTime.Format {
+    object FixedWidthTimeSerializer : FormattedLocalTimeSerializer(LocalTime.Format {
         hour(); char(':'); minute(); char(':'); second(); char('.'); secondFraction(3)
     })
 

--- a/integration-testing/serialization/common/test/LocalTimeSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalTimeSerializationTest.kt
@@ -60,17 +60,20 @@ class LocalTimeSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
+        assertKSerializerName("kotlinx.datetime.LocalTime", LocalTimeIso8601Serializer)
         iso8601Serialization(LocalTimeIso8601Serializer)
     }
 
     @Test
     fun testComponentSerialization() {
+        assertKSerializerName("kotlinx.datetime.LocalTime", LocalTimeComponentSerializer)
         componentSerialization(LocalTimeComponentSerializer)
     }
 
     @Test
     fun testDefaultSerializers() {
         // should be the same as the ISO 8601
+        assertKSerializerName<LocalTime>("kotlinx.datetime.LocalTime", Json.serializersModule.serializer())
         iso8601Serialization(Json.serializersModule.serializer())
     }
 

--- a/integration-testing/serialization/common/test/LocalTimeSerializationTest.kt
+++ b/integration-testing/serialization/common/test/LocalTimeSerializationTest.kt
@@ -73,13 +73,13 @@ class LocalTimeSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
-        assertKSerializerName("kotlinx.datetime.LocalTime ISO", LocalTimeIso8601Serializer)
+        assertKSerializerName("kotlinx.datetime.LocalTime/ISO", LocalTimeIso8601Serializer)
         iso8601Serialization(LocalTimeIso8601Serializer)
     }
 
     @Test
     fun testComponentSerialization() {
-        assertKSerializerName("kotlinx.datetime.LocalTime components", LocalTimeComponentSerializer)
+        assertKSerializerName("kotlinx.datetime.LocalTime/components", LocalTimeComponentSerializer)
         componentSerialization(LocalTimeComponentSerializer)
     }
 
@@ -95,7 +95,7 @@ class LocalTimeSerializationTest {
 
     @Test
     fun testCustomSerializer() {
-        assertKSerializerName("kotlinx.datetime.LocalTime serializer FixedWidth", FixedWidthTimeSerializer)
+        assertKSerializerName("kotlinx.datetime.LocalTime/serializer/FixedWidth", FixedWidthTimeSerializer)
         for ((localTime, json) in listOf(
             Pair(LocalTime(2, 1), "\"02:01:00.000\""),
             Pair(LocalTime(23, 59, 1), "\"23:59:01.000\""),

--- a/integration-testing/serialization/common/test/MonthSerializationTest.kt
+++ b/integration-testing/serialization/common/test/MonthSerializationTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.*
 class MonthSerializationTest {
     @Test
     fun testSerialization() {
+        assertKSerializerName("kotlinx.datetime.Month", MonthSerializer)
         for (month in Month.entries) {
             val json = "\"${month.name}\""
             assertEquals(json, Json.encodeToString(MonthSerializer, month))

--- a/integration-testing/serialization/common/test/TimeZoneSerializationTest.kt
+++ b/integration-testing/serialization/common/test/TimeZoneSerializationTest.kt
@@ -46,7 +46,11 @@ class TimeZoneSerializationTest {
 
     @Test
     fun testDefaultSerializers() {
+        assertKSerializerName<FixedOffsetTimeZone>(
+            "kotlinx.datetime.FixedOffsetTimeZone", Json.serializersModule.serializer()
+        )
         zoneOffsetSerialization(Json.serializersModule.serializer())
+        assertKSerializerName<TimeZone>("kotlinx.datetime.TimeZone", Json.serializersModule.serializer())
         serialization(Json.serializersModule.serializer())
     }
 }

--- a/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
+++ b/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
@@ -35,4 +35,20 @@ class UtcOffsetSerializationTest {
         testSerializationAsPrimitive(UtcOffsetSerializer)
         testSerializationAsPrimitive(UtcOffset.serializer())
     }
+
+    object FourDigitOffsetSerializer : CustomUtcOffsetSerializer(UtcOffset.Formats.FOUR_DIGITS)
+
+    @Test
+    fun testCustomSerializer() {
+        for ((utcOffset, json) in listOf(
+            Pair(UtcOffset.ZERO, "\"+0000\""),
+            Pair(UtcOffset(2), "\"+0200\""),
+            Pair(UtcOffset(2, 30), "\"+0230\""),
+            Pair(UtcOffset(-2, -30), "\"-0230\""),
+        )) {
+            assertEquals(json, Json.encodeToString(FourDigitOffsetSerializer, utcOffset))
+            assertEquals(utcOffset, Json.decodeFromString(FourDigitOffsetSerializer, json))
+        }
+        assertEquals("\"+1234\"", Json.encodeToString(FourDigitOffsetSerializer, UtcOffset(12, 34, 56)))
+    }
 }

--- a/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
+++ b/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
@@ -14,28 +14,50 @@ import kotlin.test.*
 
 class UtcOffsetSerializationTest {
 
-    private fun testSerializationAsPrimitive(serializer: KSerializer<UtcOffset>) {
-        val offset2h = UtcOffset(hours = 2)
-        assertEquals("\"+02:00\"", Json.encodeToString(serializer, offset2h))
-        assertEquals(offset2h, Json.decodeFromString(serializer, "\"+02:00\""))
-        assertEquals(offset2h, Json.decodeFromString(serializer, "\"+02:00:00\""))
-
-        assertFailsWith<IllegalArgumentException> {
-            Json.decodeFromString(serializer, "\"UTC+02:00\"") // not an offset
+    private fun iso8601Serialization(serializer: KSerializer<UtcOffset>) {
+        // the default form is obtainable and parsable
+        for ((offset, json) in listOf(
+            Pair(UtcOffset(hours = 0), "\"Z\""),
+            Pair(UtcOffset(hours = 1), "\"+01:00\""),
+            Pair(UtcOffset(hours = 1, minutes = 30), "\"+01:30\""),
+            Pair(UtcOffset(hours = 1, minutes = 30, seconds = 59), "\"+01:30:59\""),
+        )) {
+            assertEquals(json, Json.encodeToString(serializer, offset))
+            assertEquals(offset, Json.decodeFromString(serializer, json))
+        }
+        // alternative forms are also parsable
+        for ((offset, json) in listOf(
+            Pair(UtcOffset(hours = 0), "\"+00:00\""),
+            Pair(UtcOffset(hours = 0), "\"z\""),
+        )) {
+            assertEquals(offset, Json.decodeFromString(serializer, json))
+        }
+        // some strings aren't parsable
+        for (json in listOf(
+            "\"+3\"",
+            "\"+03\"",
+            "\"+03:0\"",
+            "\"UTC+02:00\"",
+        )) {
+            assertFailsWith<IllegalArgumentException> {
+                Json.decodeFromString(serializer, json)
+            }
         }
     }
 
     @Test
-    fun defaultSerializer() {
-        assertKSerializerName<UtcOffset>("kotlinx.datetime.UtcOffset", Json.serializersModule.serializer())
-        testSerializationAsPrimitive(Json.serializersModule.serializer())
+    fun testIso8601Serialization() {
+        assertKSerializerName<UtcOffset>("kotlinx.datetime.UtcOffset", UtcOffsetIso8601Serializer)
+        iso8601Serialization(UtcOffsetIso8601Serializer)
     }
 
     @Test
-    fun stringPrimitiveSerializer() {
-        assertKSerializerName("kotlinx.datetime.UtcOffset", UtcOffsetSerializer)
-        testSerializationAsPrimitive(UtcOffsetSerializer)
-        testSerializationAsPrimitive(UtcOffset.serializer())
+    fun testDefaultSerializers() {
+        // should be the same as the ISO 8601
+        assertKSerializerName<UtcOffset>("kotlinx.datetime.UtcOffset", Json.serializersModule.serializer())
+        iso8601Serialization(Json.serializersModule.serializer())
+        assertKSerializerName<UtcOffset>("kotlinx.datetime.UtcOffset", UtcOffset.serializer())
+        iso8601Serialization(UtcOffset.serializer())
     }
 
     object FourDigitOffsetSerializer : FormattedUtcOffsetSerializer("FOUR_DIGITS", UtcOffset.Formats.FOUR_DIGITS)

--- a/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
+++ b/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
@@ -36,10 +36,11 @@ class UtcOffsetSerializationTest {
         testSerializationAsPrimitive(UtcOffset.serializer())
     }
 
-    object FourDigitOffsetSerializer : FormattedUtcOffsetSerializer(UtcOffset.Formats.FOUR_DIGITS)
+    object FourDigitOffsetSerializer : FormattedUtcOffsetSerializer("FOUR_DIGITS", UtcOffset.Formats.FOUR_DIGITS)
 
     @Test
     fun testCustomSerializer() {
+        assertKSerializerName("kotlinx.datetime.UtcOffset serializer FOUR_DIGITS", FourDigitOffsetSerializer)
         for ((utcOffset, json) in listOf(
             Pair(UtcOffset.ZERO, "\"+0000\""),
             Pair(UtcOffset(2), "\"+0200\""),

--- a/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
+++ b/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
@@ -47,7 +47,7 @@ class UtcOffsetSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
-        assertKSerializerName<UtcOffset>("kotlinx.datetime.UtcOffset", UtcOffsetIso8601Serializer)
+        assertKSerializerName<UtcOffset>("kotlinx.datetime.UtcOffset ISO", UtcOffsetIso8601Serializer)
         iso8601Serialization(UtcOffsetIso8601Serializer)
     }
 

--- a/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
+++ b/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
@@ -27,11 +27,13 @@ class UtcOffsetSerializationTest {
 
     @Test
     fun defaultSerializer() {
+        assertKSerializerName<UtcOffset>("kotlinx.datetime.UtcOffset", Json.serializersModule.serializer())
         testSerializationAsPrimitive(Json.serializersModule.serializer())
     }
 
     @Test
     fun stringPrimitiveSerializer() {
+        assertKSerializerName("kotlinx.datetime.UtcOffset", UtcOffsetSerializer)
         testSerializationAsPrimitive(UtcOffsetSerializer)
         testSerializationAsPrimitive(UtcOffset.serializer())
     }

--- a/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
+++ b/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
@@ -36,7 +36,7 @@ class UtcOffsetSerializationTest {
         testSerializationAsPrimitive(UtcOffset.serializer())
     }
 
-    object FourDigitOffsetSerializer : CustomUtcOffsetSerializer(UtcOffset.Formats.FOUR_DIGITS)
+    object FourDigitOffsetSerializer : FormattedUtcOffsetSerializer(UtcOffset.Formats.FOUR_DIGITS)
 
     @Test
     fun testCustomSerializer() {

--- a/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
+++ b/integration-testing/serialization/common/test/UtcOffsetSerializationTest.kt
@@ -47,7 +47,7 @@ class UtcOffsetSerializationTest {
 
     @Test
     fun testIso8601Serialization() {
-        assertKSerializerName<UtcOffset>("kotlinx.datetime.UtcOffset ISO", UtcOffsetIso8601Serializer)
+        assertKSerializerName<UtcOffset>("kotlinx.datetime.UtcOffset/ISO", UtcOffsetIso8601Serializer)
         iso8601Serialization(UtcOffsetIso8601Serializer)
     }
 
@@ -64,7 +64,7 @@ class UtcOffsetSerializationTest {
 
     @Test
     fun testCustomSerializer() {
-        assertKSerializerName("kotlinx.datetime.UtcOffset serializer FOUR_DIGITS", FourDigitOffsetSerializer)
+        assertKSerializerName("kotlinx.datetime.UtcOffset/serializer/FOUR_DIGITS", FourDigitOffsetSerializer)
         for ((utcOffset, json) in listOf(
             Pair(UtcOffset.ZERO, "\"+0000\""),
             Pair(UtcOffset(2), "\"+0200\""),


### PR DESCRIPTION
* Default serializers are separated from the ISO serializers, which now mirror the behavior of `Formats.ISO` instead of `toString`/`parse`.
* New API: custom serializers parameterized with a `DateTimeFormat`.
* Serial names are properly distinct for incompatible formats.

Fixes #350
Fixes #351
Fixes #416