### PR TITLE
Annotate Instant with @JsExport

### DIFF
--- a/core/commonJs/src/Instant.kt
+++ b/core/commonJs/src/Instant.kt
@@ -7,6 +7,10 @@
 
 package kotlinx.datetime
 
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FILE
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
 import kotlinx.datetime.format.*
 import kotlinx.datetime.internal.JSJoda.Instant as jtInstant
 import kotlinx.datetime.internal.JSJoda.Duration as jtDuration
@@ -27,6 +31,8 @@ import kotlin.time.Duration.Companion.seconds
  * The actual for the JS target is [JsExport], while the actual for WASM target is
  * an annotation without any effect.
  */
+@Target(CLASS, PROPERTY, FUNCTION, FILE)
+@Retention(AnnotationRetention.BINARY)
 public expect annotation class SafeJsExport()
 
 @SafeJsExport

--- a/core/js/src/Instant.js.kt
+++ b/core/js/src/Instant.js.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2019-2024 JetBrains s.r.o. and contributors.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalJsExport::class)
+
+package kotlinx.datetime
+
+public actual typealias SafeJsExport = JsExport

--- a/core/wasmJs/src/Instant.wasmJs.kt
+++ b/core/wasmJs/src/Instant.wasmJs.kt
@@ -5,6 +5,13 @@
 
 package kotlinx.datetime
 
+import kotlin.annotation.AnnotationRetention.BINARY
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FILE
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
 
-@Retention(AnnotationRetention.SOURCE)
+
+@Retention(BINARY)
+@Target(CLASS, PROPERTY, FUNCTION, FILE)
 public actual annotation class SafeJsExport

--- a/core/wasmJs/src/Instant.wasmJs.kt
+++ b/core/wasmJs/src/Instant.wasmJs.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2019-2024 JetBrains s.r.o. and contributors.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.datetime
+
+
+@Retention(AnnotationRetention.SOURCE)
+public actual annotation class SafeJsExport


### PR DESCRIPTION
Class `Instant` has been annotated with `@JsExport` to allow usage of it from JS code. Due to [**KT-62385** @JsExport doesn't play well with the WasmTarget](https://youtrack.jetbrains.com/issue/KT-62385), a workaround has been added as well.