### PR TITLE
Add export of kotlinx.datetime.format in module-info

### DIFF
--- a/core/jvm/java9/module-info.java
+++ b/core/jvm/java9/module-info.java
@@ -4,4 +4,5 @@ module kotlinx.datetime {
 
     exports kotlinx.datetime;
     exports kotlinx.datetime.serializers;
+    exports kotlinx.datetime.format;
 }


### PR DESCRIPTION
This allows usages of the introduced format api from java 9 modules, which currently fails with the following error:

```
Kotlin: Symbol is declared in module 'kotlinx.datetime' which does not export package 'kotlinx.datetime.format'.
```