### PR TITLE
Deprecate Clock.asTimeSource

### DIFF
--- a/core/common/src/Clock.kt
+++ b/core/common/src/Clock.kt
@@ -77,9 +77,10 @@ public fun Clock.todayIn(timeZone: TimeZone): LocalDate =
  * because [Clock.System] is not well suited for measuring time intervals.
  * Please only use this conversion function on the [Clock] instances that are fully controlled programmatically.
  */
+@ExperimentalTime
 @Deprecated("This function is deprecated because Clock.System.asTimeSource " +
         "can be confused with TimeSource.Monotonic, which are very different. " +
-        "See https://github.com/Kotlin/kotlinx-datetime/issues/372", level = DeprecationLevel.ERROR)
+        "See https://github.com/Kotlin/kotlinx-datetime/issues/372", level = DeprecationLevel.WARNING)
 public fun Clock.asTimeSource(): TimeSource.WithComparableMarks = object : TimeSource.WithComparableMarks {
     @ExperimentalTime
     override fun markNow(): ComparableTimeMark = InstantTimeMark(now(), this@asTimeSource)

--- a/core/common/src/Clock.kt
+++ b/core/common/src/Clock.kt
@@ -77,8 +77,11 @@ public fun Clock.todayIn(timeZone: TimeZone): LocalDate =
  * because [Clock.System] is not well suited for measuring time intervals.
  * Please only use this conversion function on the [Clock] instances that are fully controlled programmatically.
  */
-@ExperimentalTime
+@Deprecated("This function is deprecated because Clock.System.asTimeSource " +
+        "can be confused with TimeSource.Monotonic, which are very different. " +
+        "See https://github.com/Kotlin/kotlinx-datetime/issues/372", level = DeprecationLevel.ERROR)
 public fun Clock.asTimeSource(): TimeSource.WithComparableMarks = object : TimeSource.WithComparableMarks {
+    @ExperimentalTime
     override fun markNow(): ComparableTimeMark = InstantTimeMark(now(), this@asTimeSource)
 }
 

--- a/core/common/test/ClockTimeSourceTest.kt
+++ b/core/common/test/ClockTimeSourceTest.kt
@@ -11,7 +11,7 @@ import kotlin.time.*
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.nanoseconds
 
-@OptIn(ExperimentalTime::class)
+@Suppress("DEPRECATION_ERROR")
 class ClockTimeSourceTest {
     @Test
     fun arithmetic() {

--- a/core/common/test/ClockTimeSourceTest.kt
+++ b/core/common/test/ClockTimeSourceTest.kt
@@ -11,7 +11,8 @@ import kotlin.time.*
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.nanoseconds
 
-@Suppress("DEPRECATION_ERROR")
+@OptIn(ExperimentalTime::class)
+@Suppress("DEPRECATION")
 class ClockTimeSourceTest {
     @Test
     fun arithmetic() {


### PR DESCRIPTION
Fixes https://github.com/Kotlin/kotlinx-datetime/issues/372