### PR TITLE
Enable '-jvm-default=disable' explicitly to prevent API dump changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 
 plugins {
@@ -83,6 +84,11 @@ subprojects {
                     )
                 }
             }
+        }
+    }
+    tasks.withType<KotlinJvmCompile>().configureEach {
+        compilerOptions {
+            freeCompilerArgs.add("-jvm-default=disable")
         }
     }
     tasks.withType<KotlinNativeCompile>().configureEach {


### PR DESCRIPTION
The default mode is changing from 'disable' to 'enable' in KT-71768. However, core libraries will migrate to the new '-jvm-default=enable' mode explicitly, once they update to Kotlin 2.2, see KT-72051.