### PR TITLE
Fix documentation for LocalDateFormatSamples

### DIFF
--- a/core/common/test/samples/format/LocalDateFormatSamples.kt
+++ b/core/common/test/samples/format/LocalDateFormatSamples.kt
@@ -195,10 +195,10 @@ class LocalDateFormatSamples {
         @Test
         fun constructionFromStrings() {
             // Constructing a custom set of day of week names for parsing and formatting by passing 7 strings
-            val myMonthNames = DayOfWeekNames(
+            val myDayOfWeekNames = DayOfWeekNames(
                 "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"
             )
-            check(myMonthNames == DayOfWeekNames.ENGLISH_ABBREVIATED) // could just use the built-in one...
+            check(myDayOfWeekNames == DayOfWeekNames.ENGLISH_ABBREVIATED) // could just use the built-in one...
         }
 
         @Test


### PR DESCRIPTION
Fixes small mistake in documentation for [DayOfWeekNames](https://kotlinlang.org/api/kotlinx-datetime/kotlinx-datetime/kotlinx.datetime.format/-day-of-week-names/-day-of-week-names.html)