### PR TITLE
Use -Xjvm-default instead of -jvm-default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ subprojects {
     }
     tasks.withType<KotlinJvmCompile>().configureEach {
         compilerOptions {
-            freeCompilerArgs.add("-jvm-default=disable")
+            freeCompilerArgs.add("-Xjvm-default=disable")
         }
     }
     tasks.withType<KotlinNativeCompile>().configureEach {


### PR DESCRIPTION
Apparently this branch is used in user projects to build both 2.1.20 and 2.2.0, and 2.1.20 did not support the new `-jvm-default` (KT-73007).