### PR TITLE
Enable '-Xjvm-default=disable' explicitly to prevent API dump changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,9 @@ allprojects {
         // outputs the compiler version to logs so we can check whether the train configuration applied
         kotlinOptions.freeCompilerArgs += "-version"
     }
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
+        compilerOptions { freeCompilerArgs.add("-Xjvm-default=disable") }
+    }
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile>().configureEach {
         compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=ERROR") }
     }


### PR DESCRIPTION
The default mode is changing from 'disable' to 'enable' in KT-71768. However, core libraries will migrate to the new '-jvm-default=enable' mode explicitly, once they update to Kotlin 2.2, see KT-72051.
