### PR TITLE
Upgrade to Kotlin 2.1.20

### DIFF
--- a/core/common/test/ClockTimeSourceTest.kt
+++ b/core/common/test/ClockTimeSourceTest.kt
@@ -7,10 +7,12 @@ package kotlinx.datetime.test
 
 import kotlinx.datetime.*
 import kotlin.test.*
-import kotlin.time.*
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
 
 @OptIn(ExperimentalTime::class)
 @Suppress("DEPRECATION")

--- a/core/common/test/InstantTest.kt
+++ b/core/common/test/InstantTest.kt
@@ -10,7 +10,7 @@ import kotlinx.datetime.format.*
 import kotlinx.datetime.internal.*
 import kotlin.random.*
 import kotlin.test.*
-import kotlin.time.*
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds

--- a/core/common/test/LocalDateTimeTest.kt
+++ b/core/common/test/LocalDateTimeTest.kt
@@ -8,7 +8,7 @@ package kotlinx.datetime.test
 import kotlinx.datetime.*
 import kotlinx.datetime.Clock
 import kotlin.test.*
-import kotlin.time.*
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.days
 

--- a/core/common/test/ReadmeTest.kt
+++ b/core/common/test/ReadmeTest.kt
@@ -8,7 +8,7 @@ package kotlinx.datetime.test
 import kotlinx.datetime.*
 import kotlinx.datetime.format.*
 import kotlin.test.*
-import kotlin.time.*
+import kotlin.time.Duration
 
 /**
  * Tests the code snippets in the README.md file.

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ versionSuffix=SNAPSHOT
 
 tzdbVersion=2025a
 
-defaultKotlinVersion=2.1.0
+defaultKotlinVersion=2.1.20
 dokkaVersion=1.9.20
 serializationVersion=1.6.2
 benchmarksVersion=0.7.2


### PR DESCRIPTION
The changes in `import` statements are due to the stdlib now having its own `Instant` and `Clock`, which leads to resolution conflicts when star imports `kotlinx.datetime.*` and `kotlin.time.*` are used.