### PR TITLE
Update kotlinx.team.infra plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("kotlinx.team.infra") version "0.4.0-dev-81"
+    id("kotlinx.team.infra") version "0.4.0-dev-85"
     kotlin("multiplatform") apply false
     id("org.jetbrains.kotlinx.kover") version "0.8.0-Beta2"
 }

--- a/serialization/build.gradle.kts
+++ b/serialization/build.gradle.kts
@@ -114,8 +114,5 @@ kotlin {
                 runtimeOnly(project(":kotlinx-datetime-zoneinfo"))
             }
         }
-
-        val nativeMain by getting
-        val nativeTest by getting
     }
 }


### PR DESCRIPTION
Update kotlinx.team.infra to a version that no longer provides native targets and source-set setup functionality that is incompatible with KGP 2.2+.