### PR TITLE
Add explicit `serialVersionUID` to exception classes

### DIFF
--- a/core/common/src/Exceptions.kt
+++ b/core/common/src/Exceptions.kt
@@ -13,6 +13,10 @@ public class DateTimeArithmeticException: RuntimeException {
     public constructor(message: String): super(message)
     public constructor(cause: Throwable): super(cause)
     public constructor(message: String, cause: Throwable): super(message, cause)
+
+    private companion object {
+        private const val serialVersionUID: Long = -3207806170214997982L
+    }
 }
 
 /**
@@ -23,6 +27,10 @@ public class IllegalTimeZoneException: IllegalArgumentException {
     public constructor(message: String): super(message)
     public constructor(cause: Throwable): super(cause)
     public constructor(message: String, cause: Throwable): super(message, cause)
+
+    private companion object {
+        private const val serialVersionUID: Long = 1159315966274264801L
+    }
 }
 
 internal class DateTimeFormatException: IllegalArgumentException {
@@ -30,4 +38,8 @@ internal class DateTimeFormatException: IllegalArgumentException {
     constructor(message: String): super(message)
     constructor(cause: Throwable): super(cause)
     constructor(message: String, cause: Throwable): super(message, cause)
+
+    private companion object {
+        private const val serialVersionUID: Long = 4231196759387994100L
+    }
 }

--- a/core/common/src/internal/format/parser/Parser.kt
+++ b/core/common/src/internal/format/parser/Parser.kt
@@ -209,7 +209,13 @@ internal value class Parser<Output : Copyable<Output>>(
     )
 }
 
-internal class ParseException(errors: List<ParseError>) : Exception(formatError(errors))
+// note that the message of this exception could be anything (even null) after deserialization of a manually constructed
+// or corrupted stream (via Java Object Serialization)
+internal class ParseException(errors: List<ParseError>) : Exception(formatError(errors)) {
+    private companion object {
+        private const val serialVersionUID: Long = 5691186997393344103L
+    }
+}
 
 private fun formatError(errors: List<ParseError>): String {
     if (errors.size == 1) {


### PR DESCRIPTION
This ensures that unrelated changes in these exception classes don't affect the serialized form.

The `serialVersionUID`s are from `v0.6.2` and were obtained with the [serialver tool](https://docs.oracle.com/en/java/javase/21/docs/specs/man/serialver.html):
```
$ serialver -classpath kotlinx-datetime-jvm-0.6.2.jar:kotlin-stdlib-1.9.21.jar kotlinx.datetime.DateTimeArithmeticException kotlinx.datetime.IllegalTimeZoneException kotlinx.datetime.DateTimeFormatException kotlinx.datetime.internal.format.parser.ParseException
kotlinx.datetime.DateTimeArithmeticException:    private static final long serialVersionUID = -3207806170214997982L;
kotlinx.datetime.IllegalTimeZoneException:    private static final long serialVersionUID = 1159315966274264801L;
kotlinx.datetime.DateTimeFormatException:    private static final long serialVersionUID = 4231196759387994100L;
kotlinx.datetime.internal.format.parser.ParseException:    private static final long serialVersionUID = 5691186997393344103L;
```