### PR TITLE
Restore binary compatibility of `year()` and `monthNumber()`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ allprojects {
         kotlinOptions.freeCompilerArgs += "-version"
     }
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
-        compilerOptions { freeCompilerArgs.add("-Xjvm-default=disable") }
+        compilerOptions { freeCompilerArgs.add("-Xjvm-default=all-compatibility") }
     }
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile>().configureEach {
         compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=ERROR") }

--- a/core/api/kotlinx-datetime.api
+++ b/core/api/kotlinx-datetime.api
@@ -892,6 +892,7 @@ public final class kotlinx/datetime/format/DateTimeFormatBuilder$WithDate$Defaul
 	public static final fun day$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public static final fun dayOfMonth (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;)V
 	public static final fun dayOfMonth$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+	public static final fun dayOfYear$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public static final fun monthNumber$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public static final fun year$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 }
@@ -900,6 +901,7 @@ public final class kotlinx/datetime/format/DateTimeFormatBuilder$WithDate$Defaul
 	public final fun day$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public final fun dayOfMonth (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;)V
 	public final fun dayOfMonth$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+	public final fun dayOfYear$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public final fun monthNumber$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public final fun year$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 }

--- a/core/api/kotlinx-datetime.api
+++ b/core/api/kotlinx-datetime.api
@@ -878,16 +878,30 @@ public abstract interface class kotlinx/datetime/format/DateTimeFormatBuilder {
 public abstract interface class kotlinx/datetime/format/DateTimeFormatBuilder$WithDate : kotlinx/datetime/format/DateTimeFormatBuilder$WithYearMonth {
 	public abstract fun date (Lkotlinx/datetime/format/DateTimeFormat;)V
 	public abstract fun day (Lkotlinx/datetime/format/Padding;)V
-	public abstract fun dayOfMonth (Lkotlinx/datetime/format/Padding;)V
+	public static synthetic fun day$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+	public fun dayOfMonth (Lkotlinx/datetime/format/Padding;)V
+	public static synthetic fun dayOfMonth$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public abstract fun dayOfWeek (Lkotlinx/datetime/format/DayOfWeekNames;)V
 	public abstract fun dayOfYear (Lkotlinx/datetime/format/Padding;)V
+	public static synthetic fun dayOfYear$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 }
 
 public final class kotlinx/datetime/format/DateTimeFormatBuilder$WithDate$DefaultImpls {
-	public static synthetic fun day$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
-	public static fun dayOfMonth (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;)V
-	public static synthetic fun dayOfMonth$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
-	public static synthetic fun dayOfYear$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+	public static final field Companion Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate$DefaultImpls$Companion;
+	public fun <init> ()V
+	public static final fun day$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+	public static final fun dayOfMonth (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;)V
+	public static final fun dayOfMonth$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+	public static final fun monthNumber$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+	public static final fun year$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+}
+
+public final class kotlinx/datetime/format/DateTimeFormatBuilder$WithDate$DefaultImpls$Companion {
+	public final fun day$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+	public final fun dayOfMonth (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;)V
+	public final fun dayOfMonth$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+	public final fun monthNumber$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+	public final fun year$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 }
 
 public abstract interface class kotlinx/datetime/format/DateTimeFormatBuilder$WithDateTime : kotlinx/datetime/format/DateTimeFormatBuilder$WithDate, kotlinx/datetime/format/DateTimeFormatBuilder$WithTime {
@@ -911,12 +925,17 @@ public final class kotlinx/datetime/format/DateTimeFormatBuilder$WithDateTimeCom
 
 public abstract interface class kotlinx/datetime/format/DateTimeFormatBuilder$WithTime : kotlinx/datetime/format/DateTimeFormatBuilder {
 	public abstract fun amPmHour (Lkotlinx/datetime/format/Padding;)V
+	public static synthetic fun amPmHour$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithTime;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public abstract fun amPmMarker (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun hour (Lkotlinx/datetime/format/Padding;)V
+	public static synthetic fun hour$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithTime;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public abstract fun minute (Lkotlinx/datetime/format/Padding;)V
+	public static synthetic fun minute$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithTime;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public abstract fun second (Lkotlinx/datetime/format/Padding;)V
-	public abstract fun secondFraction (I)V
+	public static synthetic fun second$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithTime;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+	public fun secondFraction (I)V
 	public abstract fun secondFraction (II)V
+	public static synthetic fun secondFraction$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithTime;IIILjava/lang/Object;)V
 	public abstract fun time (Lkotlinx/datetime/format/DateTimeFormat;)V
 }
 
@@ -932,8 +951,11 @@ public final class kotlinx/datetime/format/DateTimeFormatBuilder$WithTime$Defaul
 public abstract interface class kotlinx/datetime/format/DateTimeFormatBuilder$WithUtcOffset : kotlinx/datetime/format/DateTimeFormatBuilder {
 	public abstract fun offset (Lkotlinx/datetime/format/DateTimeFormat;)V
 	public abstract fun offsetHours (Lkotlinx/datetime/format/Padding;)V
+	public static synthetic fun offsetHours$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithUtcOffset;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public abstract fun offsetMinutesOfHour (Lkotlinx/datetime/format/Padding;)V
+	public static synthetic fun offsetMinutesOfHour$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithUtcOffset;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public abstract fun offsetSecondsOfMinute (Lkotlinx/datetime/format/Padding;)V
+	public static synthetic fun offsetSecondsOfMinute$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithUtcOffset;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 }
 
 public final class kotlinx/datetime/format/DateTimeFormatBuilder$WithUtcOffset$DefaultImpls {
@@ -945,7 +967,9 @@ public final class kotlinx/datetime/format/DateTimeFormatBuilder$WithUtcOffset$D
 public abstract interface class kotlinx/datetime/format/DateTimeFormatBuilder$WithYearMonth : kotlinx/datetime/format/DateTimeFormatBuilder {
 	public abstract fun monthName (Lkotlinx/datetime/format/MonthNames;)V
 	public abstract fun monthNumber (Lkotlinx/datetime/format/Padding;)V
+	public static synthetic fun monthNumber$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithYearMonth;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public abstract fun year (Lkotlinx/datetime/format/Padding;)V
+	public static synthetic fun year$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithYearMonth;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 	public abstract fun yearMonth (Lkotlinx/datetime/format/DateTimeFormat;)V
 	public abstract fun yearTwoDigits (I)V
 }

--- a/core/common/src/format/DateTimeFormatBuilder.kt
+++ b/core/common/src/format/DateTimeFormatBuilder.kt
@@ -9,6 +9,10 @@ import kotlinx.datetime.*
 import kotlinx.datetime.internal.*
 import kotlinx.datetime.internal.format.*
 
+@OptIn(ExperimentalMultiplatform::class)
+@OptionalExpectation
+internal expect annotation class MyJvmDefaultWithoutCompatibility()
+
 /**
  * Common functions for all format builders.
  */
@@ -85,6 +89,7 @@ public sealed interface DateTimeFormatBuilder {
     /**
      * Functions specific to the datetime format builders containing the local-date fields.
      */
+    @MyJvmDefaultWithoutCompatibility
     public sealed interface WithDate : WithYearMonth {
         /**
          * A day-of-month number, from 1 to 31.

--- a/core/jvm/src/format/Deprecations.kt
+++ b/core/jvm/src/format/Deprecations.kt
@@ -19,11 +19,17 @@ internal class `DateTimeFormatBuilder$WithDate$DefaultImpls` {
     // public static synthetic fun day$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
     // public static fun dayOfMonth (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;)V
     // public static synthetic fun dayOfMonth$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+    // public static synthetic fun dayOfYear$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
 
     companion object {
         @JvmStatic
         fun `monthNumber$default`(format: DateTimeFormatBuilder.WithDate, padding: Padding?, i: Int, j: Any?) {
             format.monthNumber()
+        }
+
+        @JvmStatic
+        fun `dayOfYear$default`(format: DateTimeFormatBuilder.WithDate, padding: Padding?, i: Int, j: Any?) {
+            format.dayOfYear()
         }
 
         @JvmStatic

--- a/core/jvm/src/format/Deprecations.kt
+++ b/core/jvm/src/format/Deprecations.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019-2025 JetBrains s.r.o. and contributors.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.datetime.format
+
+/**
+ * This class preserves backward compatibility with the version 0.6.2 of `kotlinx-datetime`,
+ * where `year` and `monthNumber` with default values were parts of the `WithDate` interface.
+ *
+ * Now, these methods were moved to the `WithYearMonth` interface,
+ * but the static methods corresponding to the default values are not inherited.
+ */
+@PublishedApi
+internal class `DateTimeFormatBuilder$WithDate$DefaultImpls` {
+    // public static synthetic fun monthNumber$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+    // public static synthetic fun year$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+    // public static synthetic fun day$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+    // public static fun dayOfMonth (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;)V
+    // public static synthetic fun dayOfMonth$default (Lkotlinx/datetime/format/DateTimeFormatBuilder$WithDate;Lkotlinx/datetime/format/Padding;ILjava/lang/Object;)V
+
+    companion object {
+        @JvmStatic
+        fun `monthNumber$default`(format: DateTimeFormatBuilder.WithDate, padding: Padding?, i: Int, j: Any?) {
+            format.monthNumber()
+        }
+
+        @JvmStatic
+        fun `year$default`(format: DateTimeFormatBuilder.WithDate, padding: Padding?, i: Int, j: Any?) {
+            format.year()
+        }
+
+        @JvmStatic
+        fun `day$default`(format: DateTimeFormatBuilder.WithDate, padding: Padding?, i: Int, j: Any?) {
+            format.day()
+        }
+
+        @JvmStatic
+        fun dayOfMonth(format: DateTimeFormatBuilder.WithDate, padding: Padding?) {
+            format.day(padding = padding ?: Padding.ZERO)
+        }
+
+        @JvmStatic
+        fun `dayOfMonth$default`(format: DateTimeFormatBuilder.WithDate, padding: Padding?, i: Int, j: Any?) {
+            format.day()
+        }
+    }
+}

--- a/core/jvm/src/format/format/MyJvmDefaultWithoutCompatibility.kt
+++ b/core/jvm/src/format/format/MyJvmDefaultWithoutCompatibility.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2019-2025 JetBrains s.r.o. and contributors.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.datetime.format
+
+internal actual typealias MyJvmDefaultWithoutCompatibility = JvmDefaultWithoutCompatibility


### PR DESCRIPTION
Fixes #545