### PR TITLE
Support new maven central publication scheme

### DIFF
--- a/.teamcity/CentralDeployment.kt
+++ b/.teamcity/CentralDeployment.kt
@@ -45,12 +45,6 @@ fun Project.startDeployment() = BuildType {
             "",
             display = ParameterDisplay.PROMPT
         )
-        select(
-            "Repository",
-            "central",
-            options = listOf("central", "sonatype"),
-            display = ParameterDisplay.PROMPT
-        )
         text(
             "ZoneInfoVersion",
             "",
@@ -81,7 +75,6 @@ fun Project.deployToCentral(startDeployment: BuildType) = buildType("DeployCentr
     params {
         param(versionSuffixParameter, "${startDeployment.depParamRefs["VersionSuffix"]}")
         param(releaseVersionParameter, "${startDeployment.depParamRefs["Version"]}")
-        param("system.publication_repository", "${startDeployment.depParamRefs["Repository"]}")
     }
 
     vcs {

--- a/.teamcity/CentralDeployment.kt
+++ b/.teamcity/CentralDeployment.kt
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2019-2025 JetBrains s.r.o. and contributors.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.buildSteps.*
+import jetbrains.buildServer.configs.kotlin.triggers.finishBuildTrigger
+
+fun deploymentProject() = Project {
+    this.id("Deployment")
+    this.name = "Deployment"
+
+    params {
+        param("teamcity.ui.settings.readOnly", "true")
+    }
+
+    val startDeploymentTask = startDeployment()
+
+    val copyToCentralTask = copyToCentral(startDeploymentTask)
+    val copyZoneInfoTask = copyZoneInfoToCentral(startDeploymentTask)
+
+    val deployTasks = buildList {
+        Platform.entries.forEach {
+            add(deployToCentral(it, startDeploymentTask))
+        }
+    }
+
+    deployTasks.forEach { deploy ->
+        copyToCentralTask.dependsOnSnapshot(deploy, onFailure = FailureAction.CANCEL)
+        copyZoneInfoTask.dependsOnSnapshot(deploy, onFailure = FailureAction.CANCEL)
+    }
+
+    buildTypesOrder = listOf(startDeploymentTask, *deployTasks.toTypedArray()) + listOf(copyToCentralTask, copyZoneInfoTask)
+}
+
+fun Project.startDeployment() = BuildType {
+    id("StartDeployment")
+    this.name = "Start Deployment [RUN THIS ONE]"
+    type = BuildTypeSettings.Type.DEPLOYMENT
+
+    params {
+        text(
+            "Version",
+            "",
+            display = ParameterDisplay.PROMPT,
+            allowEmpty = false
+        )
+        text(
+            "VersionSuffix",
+            "",
+            display = ParameterDisplay.PROMPT
+        )
+        select(
+            "Repository",
+            "central",
+            options = listOf("central", "sonatype"),
+            display = ParameterDisplay.PROMPT
+        )
+        text(
+            "ZoneInfoVersion",
+            "",
+            display = ParameterDisplay.HIDDEN
+        )
+    }
+
+    steps {
+        gradle {
+            name = "Get ZoneInfoVersion"
+            jdkHome = "%env.$jdk%"
+            jvmArgs = "-Xmx1g"
+            gradleParams =
+                "--info --stacktrace -P$versionSuffixParameter=%VersionSuffix% -P$releaseVersionParameter=%Version% -Pzoneinfo.version.tc.parameter=ZoneInfoVersion"
+            tasks = ":kotlinx-datetime-zoneinfo:setZoneInfoVersionToTeamcity"
+            buildFile = ""
+            gradleWrapperPath = ""
+        }
+    }
+
+    commonConfigure()
+}.also { buildType(it) }
+
+fun Project.deployToCentral(platform: Platform, startDeployment: BuildType) = buildType("DeployCentral", platform) {
+    type = BuildTypeSettings.Type.DEPLOYMENT
+    enablePersonalBuilds = false
+    maxRunningBuilds = 1
+    params {
+        param(versionSuffixParameter, "${startDeployment.depParamRefs["VersionSuffix"]}")
+        param(releaseVersionParameter, "${startDeployment.depParamRefs["Version"]}")
+        param("system.publication_repository", "${startDeployment.depParamRefs["Repository"]}")
+    }
+
+    vcs {
+        cleanCheckout = true
+    }
+
+    val taskNames = buildList {
+        add("clean")
+        when (platform) {
+            Platform.Linux -> {
+                addAll(
+                    listOf(
+                        "publishAndroidNativeArm32PublicationToCentralRepository",
+                        "publishAndroidNativeArm64PublicationToCentralRepository",
+                        "publishAndroidNativeX64PublicationToCentralRepository",
+                        "publishAndroidNativeX86PublicationToCentralRepository",
+                        "publishLinuxArm64PublicationToCentralRepository",
+                        "publishLinuxX64PublicationToCentralRepository"
+                    )
+                )
+            }
+
+            Platform.Windows -> {
+                add("publishMingwX64PublicationToCentralRepository")
+            }
+
+            Platform.MacOS -> {
+                addAll(
+                    listOf(
+                        // metadata
+                        "publishKotlinMultiplatformPublicationToCentralRepository",
+                        // web
+                        "publishJsPublicationToCentralRepository",
+                        "publishWasmJsPublicationToCentralRepository",
+                        "publishWasmWasiPublicationToCentralRepository",
+                        // jvm
+                        "publishJvmPublicationToCentralRepository",
+                        // native
+                        "publishIosArm64PublicationToCentralRepository",
+                        "publishIosSimulatorArm64PublicationToCentralRepository",
+                        "publishIosX64PublicationToCentralRepository",
+                        "publishMacosArm64PublicationToCentralRepository",
+                        "publishMacosX64PublicationToCentralRepository",
+                        "publishTvosArm64PublicationToCentralRepository",
+                        "publishTvosSimulatorArm64PublicationToCentralRepository",
+                        "publishTvosX64PublicationToCentralRepository",
+                        "publishWatchosArm32PublicationToCentralRepository",
+                        "publishWatchosArm64PublicationToCentralRepository",
+                        "publishWatchosDeviceArm64PublicationToCentralRepository",
+                        "publishWatchosSimulatorArm64PublicationToCentralRepository",
+                        "publishWatchosX64PublicationToCentralRepository"
+                    )
+                )
+            }
+        }
+    }
+
+    steps {
+        gradle {
+            name = "Deploy ${platform.buildTypeName()} Binaries"
+            jdkHome = "%env.$jdk%"
+            jvmArgs = "-Xmx1g"
+            gradleParams =
+                "--info --stacktrace -P$versionSuffixParameter=%$versionSuffixParameter% -P$releaseVersionParameter=%$releaseVersionParameter%"
+            tasks = taskNames.joinToString(" ")
+            buildFile = ""
+            gradleWrapperPath = ""
+        }
+    }
+}.dependsOnSnapshot(startDeployment)
+
+fun Project.copyToCentral(startDeployment: BuildType) = BuildType {
+    id("CopyToCentral")
+    this.name = "Deploy To Central"
+    type = BuildTypeSettings.Type.DEPLOYMENT
+
+    templates(AbsoluteId("KotlinTools_DeployToCentral"))
+
+    params {
+        param("DeployVersion", startDeployment.depParamRefs["Version"].ref)
+        param("ArtifactPrefixes", "[kotlinx-datetime]")
+    }
+
+    requirements {
+        doesNotMatch("teamcity.agent.jvm.os.name", "Windows")
+    }
+
+    dependsOnSnapshot(startDeployment)
+
+    triggers {
+        finishBuildTrigger {
+            buildType = "${startDeployment.id}"
+            successfulOnly = true
+            branchFilter = "+:*"
+        }
+    }
+}.also { buildType(it) }
+
+fun Project.copyZoneInfoToCentral(startDeployment: BuildType) = BuildType {
+    id("CopyZoneInfoToCentral")
+    this.name = "Deploy ZoneInfo To Central"
+    type = BuildTypeSettings.Type.DEPLOYMENT
+
+    templates(AbsoluteId("KotlinTools_DeployToCentral"))
+
+    params {
+        param("DeployVersion", startDeployment.depParamRefs["ZoneInfoVersion"].ref)
+        param("ArtifactPrefixes", "[kotlinx-datetime-zoneinfo]")
+    }
+
+    requirements {
+        doesNotMatch("teamcity.agent.jvm.os.name", "Windows")
+    }
+
+    dependsOnSnapshot(startDeployment)
+
+    triggers {
+        finishBuildTrigger {
+            buildType = "${startDeployment.id}"
+            successfulOnly = true
+            branchFilter = "+:*"
+        }
+    }
+}.also { buildType(it) }

--- a/.teamcity/CentralDeployment.kt
+++ b/.teamcity/CentralDeployment.kt
@@ -48,21 +48,12 @@ fun Project.startDeployment() = BuildType {
         text(
             "ZoneInfoVersion",
             "",
-            display = ParameterDisplay.HIDDEN
+            display = ParameterDisplay.PROMPT,
+            allowEmpty = false
         )
     }
 
     steps {
-        gradle {
-            name = "Get ZoneInfoVersion"
-            jdkHome = "%env.$jdk%"
-            jvmArgs = "-Xmx1g"
-            gradleParams =
-                "--info --stacktrace -P$versionSuffixParameter=%VersionSuffix% -P$releaseVersionParameter=%Version% -Pzoneinfo.version.tc.parameter=ZoneInfoVersion"
-            tasks = ":kotlinx-datetime-zoneinfo:setZoneInfoVersionToTeamcity"
-            buildFile = ""
-            gradleWrapperPath = ""
-        }
     }
 
     commonConfigure()

--- a/.teamcity/additionalConfiguration.kt
+++ b/.teamcity/additionalConfiguration.kt
@@ -15,6 +15,8 @@ import jetbrains.buildServer.configs.kotlin.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot
 
 fun Project.additionalConfiguration() {
+    subProjects(deploymentProject())
+
     knownBuilds.buildAll.features {
         commitStatusPublisher {
             vcsRootExtId = "${DslContext.settingsRoot.id}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,12 +14,7 @@ infra {
         include(":kotlinx-datetime")
         include(":kotlinx-datetime-zoneinfo")
         libraryRepoUrl = "https://github.com/Kotlin/kotlinx-datetime"
-        if (project.findProperty("publication_repository") == "central") {
-            central {}
-        }
-        sonatype {
-            libraryStagingRepoDescription = project.name
-        }
+        central {}
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
-    id("kotlinx.team.infra") version "0.4.0-dev-85"
+    id("kotlinx.team.infra") version "0.4.0-dev-86"
     kotlin("multiplatform") apply false
     id("org.jetbrains.kotlinx.kover") version "0.8.0-Beta2"
 }
@@ -14,6 +14,9 @@ infra {
         include(":kotlinx-datetime")
         include(":kotlinx-datetime-zoneinfo")
         libraryRepoUrl = "https://github.com/Kotlin/kotlinx-datetime"
+        if (project.findProperty("publication_repository") == "central") {
+            central {}
+        }
         sonatype {
             libraryStagingRepoDescription = project.name
         }

--- a/timezones/full/build.gradle.kts
+++ b/timezones/full/build.gradle.kts
@@ -97,3 +97,19 @@ apiValidation {
         enabled = true
     }
 }
+
+if (project.hasProperty("teamcity")) {
+    tasks.register("setZoneInfoVersionToTeamcity") {
+        doLast {
+            var tcParameter = (project.findProperty("zoneinfo.version.tc.parameter") as String?).let {
+                if (it == null) {
+                    logger.warn("Teamcity parameter name was not specified, using 'ZoneInfoVersion' instead")
+                    "ZoneInfoVersion"
+                } else {
+                    it
+                }
+            }
+            println("##teamcity[setParameter name='$tcParameter' value='$version']")
+        }
+    }
+}


### PR DESCRIPTION
It is not longer possible to publish artifacts to sonatype staging repositories and the central publishing portal has to be used instead.
The PR adds TC jobs publishing all the artifacts into intermediate maven repo and then collect all the artifacts into a single deployment uploaded to the portal.
