### PR TITLE
Add support for ordinal day formatting

### DIFF
--- a/core/common/src/format/DateTimeFormatBuilder.kt
+++ b/core/common/src/format/DateTimeFormatBuilder.kt
@@ -101,7 +101,7 @@ public sealed interface DateTimeFormatBuilder {
         public fun day(padding: Padding = Padding.ZERO)
 
         /**
-         * A day-of-month ordinal number.
+         * A day-of-month ordinal.
          *
          * @sample kotlinx.datetime.test.samples.format.LocalDateFormatSamples.dayOrdinal
          */
@@ -109,9 +109,7 @@ public sealed interface DateTimeFormatBuilder {
 
         /** @suppress */
         @Deprecated("Use 'day' instead", ReplaceWith("day(padding = padding)"))
-        public fun dayOfMonth(padding: Padding = Padding.ZERO) {
-            day(padding)
-        }
+        public fun dayOfMonth(padding: Padding = Padding.ZERO) { day(padding) }
 
         /**
          * A day-of-week name (for example, "Thursday").

--- a/core/common/src/format/DateTimeFormatBuilder.kt
+++ b/core/common/src/format/DateTimeFormatBuilder.kt
@@ -100,9 +100,18 @@ public sealed interface DateTimeFormatBuilder {
          */
         public fun day(padding: Padding = Padding.ZERO)
 
+        /**
+         * A day-of-month number with an ordinal suffix (for example, "1st", "2nd", "3rd", "4th").
+         *
+         * @sample kotlinx.datetime.test.samples.format.LocalDateFormatSamples.dayOrdinal
+         */
+        public fun dayOrdinal(names: DayOrdinalNames)
+
         /** @suppress */
         @Deprecated("Use 'day' instead", ReplaceWith("day(padding = padding)"))
-        public fun dayOfMonth(padding: Padding = Padding.ZERO) { day(padding) }
+        public fun dayOfMonth(padding: Padding = Padding.ZERO) {
+            day(padding)
+        }
 
         /**
          * A day-of-week name (for example, "Thursday").

--- a/core/common/src/format/DateTimeFormatBuilder.kt
+++ b/core/common/src/format/DateTimeFormatBuilder.kt
@@ -101,7 +101,7 @@ public sealed interface DateTimeFormatBuilder {
         public fun day(padding: Padding = Padding.ZERO)
 
         /**
-         * A day-of-month number with an ordinal suffix (for example, "1st", "2nd", "3rd", "4th").
+         * A day-of-month ordinal number.
          *
          * @sample kotlinx.datetime.test.samples.format.LocalDateFormatSamples.dayOrdinal
          */

--- a/core/common/src/format/LocalDateFormat.kt
+++ b/core/common/src/format/LocalDateFormat.kt
@@ -222,9 +222,38 @@ private class OrdinalDayDirective(
     override fun hashCode(): Int = names.names.hashCode()
 }
 
-public class DayOrdinalNames(public val names: List<String>) {
+
+/**
+ * A description of how the names of ordinal days are formatted.
+ *
+ * Instances of this class are typically used as arguments to [DateTimeFormatBuilder.WithDate.dayOrdinal].
+ *
+ * A predefined instance is available as [ENGLISH].
+ * You can also create custom instances using the constructor.
+ *
+ * An [IllegalArgumentException] will be thrown if the list does not contain exactly 31 elements.
+ *
+ * @sample kotlinx.datetime.test.samples.format.LocalDateFormatSamples.DayOrdinalNamesSamples.usage
+ * @sample kotlinx.datetime.test.samples.format.LocalDateFormatSamples.DayOrdinalNamesSamples.customNames
+ */
+public class DayOrdinalNames(
+    /**
+     * A list of the names of ordinal days from 1st to 31st.
+     *
+     * @sample kotlinx.datetime.test.samples.format.LocalDateFormatSamples.DayOrdinalNamesSamples.names
+     */
+    public val names: List<String>
+) {
     init {
-        require(names.size == 31) { "Ordinal day suffixes must contain exactly 31 elements" }
+        /**
+         * The list must contain exactly 31 elements, one for each day of the month.
+         * The names are expected to be in the order from 1st to 31st.
+         *
+         * @sample kotlinx.datetime.test.samples.format.LocalDateFormatSamples.DayOrdinalNamesSamples.invalidListSize
+         */
+        require(names.size == 31) {
+            "Day ordinal names must contain exactly 31 elements, one for each day of the month"
+        }
     }
 
     public companion object {

--- a/core/common/test/format/LocalDateFormatTest.kt
+++ b/core/common/test/format/LocalDateFormatTest.kt
@@ -7,9 +7,11 @@
 
 package kotlinx.datetime.test.format
 
-import kotlinx.datetime.*
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.format.*
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class LocalDateFormatTest {
 
@@ -233,22 +235,13 @@ class LocalDateFormatTest {
     @Test
     fun testDoc() {
         val format = LocalDate.Format {
-          year()
-          char(' ')
-          monthName(MonthNames.ENGLISH_ABBREVIATED)
-          char(' ')
-          day()
+            year()
+            char(' ')
+            monthName(MonthNames.ENGLISH_ABBREVIATED)
+            char(' ')
+            day()
         }
         assertEquals("2020 Jan 05", format.format(LocalDate(2020, 1, 5)))
-    }
-
-    @Test
-    fun testEmptyDayOfWeekNames() {
-        val names = DayOfWeekNames.ENGLISH_FULL.names
-        for (i in 0 until 7) {
-            val newNames = (0 until 7).map { if (it == i) "" else names[it] }
-            assertFailsWith<IllegalArgumentException> { DayOfWeekNames(newNames) }
-        }
     }
 
     @Test
@@ -256,6 +249,38 @@ class LocalDateFormatTest {
         assertFailsWith<IllegalArgumentException> {
             DayOfWeekNames("Mon", "Tue", "Tue", "Thu", "Fri", "Sat", "Sun")
         }
+    }
+
+    @Test
+    fun testDayOrdinalFormatting() {
+        val format = LocalDate.Format {
+            dayOrdinal(DayOrdinalNames.ENGLISH); char(' '); monthName(MonthNames.ENGLISH_ABBREVIATED)
+        }
+        val testCases = listOf(
+            LocalDate(2021, 1, 1) to "1st Jan",
+            LocalDate(2021, 1, 2) to "2nd Jan",
+            LocalDate(2021, 1, 3) to "3rd Jan",
+            LocalDate(2021, 1, 4) to "4th Jan",
+            LocalDate(2021, 1, 11) to "11th Jan",
+            LocalDate(2021, 1, 21) to "21st Jan",
+            LocalDate(2021, 1, 22) to "22nd Jan",
+            LocalDate(2021, 1, 23) to "23rd Jan",
+            LocalDate(2021, 1, 31) to "31st Jan"
+        )
+        for ((date, expected) in testCases) {
+            assertEquals(expected, format.format(date), "Failed for $date")
+        }
+    }
+
+    @Test
+    fun testDayOrdinalCustomNames() {
+        val customNames = DayOrdinalNames(List(31) { i -> "${i + 1}th" })
+        val format = LocalDate.Format {
+            dayOrdinal(customNames); char(' '); monthName(MonthNames.ENGLISH_ABBREVIATED)
+        }
+        assertEquals("1th Jan", format.format(LocalDate(2021, 1, 1)))
+        assertEquals("2th Jan", format.format(LocalDate(2021, 1, 2)))
+        assertEquals("31th Jan", format.format(LocalDate(2021, 1, 31)))
     }
 
     private fun test(strings: Map<LocalDate, Pair<String, Set<String>>>, format: DateTimeFormat<LocalDate>) {

--- a/core/common/test/format/LocalDateFormatTest.kt
+++ b/core/common/test/format/LocalDateFormatTest.kt
@@ -7,11 +7,9 @@
 
 package kotlinx.datetime.test.format
 
-import kotlinx.datetime.LocalDate
+import kotlinx.datetime.*
 import kotlinx.datetime.format.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import kotlin.test.*
 
 class LocalDateFormatTest {
 
@@ -235,13 +233,22 @@ class LocalDateFormatTest {
     @Test
     fun testDoc() {
         val format = LocalDate.Format {
-            year()
-            char(' ')
-            monthName(MonthNames.ENGLISH_ABBREVIATED)
-            char(' ')
-            day()
+          year()
+          char(' ')
+          monthName(MonthNames.ENGLISH_ABBREVIATED)
+          char(' ')
+          day()
         }
         assertEquals("2020 Jan 05", format.format(LocalDate(2020, 1, 5)))
+    }
+
+    @Test
+    fun testEmptyDayOfWeekNames() {
+        val names = DayOfWeekNames.ENGLISH_FULL.names
+        for (i in 0 until 7) {
+            val newNames = (0 until 7).map { if (it == i) "" else names[it] }
+            assertFailsWith<IllegalArgumentException> { DayOfWeekNames(newNames) }
+        }
     }
 
     @Test

--- a/core/common/test/samples/format/LocalDateFormatSamples.kt
+++ b/core/common/test/samples/format/LocalDateFormatSamples.kt
@@ -5,10 +5,9 @@
 
 package kotlinx.datetime.test.samples.format
 
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.*
 import kotlinx.datetime.format.*
-import kotlin.test.Test
+import kotlin.test.*
 
 class LocalDateFormatSamples {
     @Test
@@ -108,11 +107,9 @@ class LocalDateFormatSamples {
         @Test
         fun names() {
             // Obtaining the list of day of week names
-            check(
-                DayOfWeekNames.ENGLISH_ABBREVIATED.names == listOf(
-                    "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"
-                )
-            )
+            check(DayOfWeekNames.ENGLISH_ABBREVIATED.names == listOf(
+                "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"
+            ))
         }
 
         @Test

--- a/core/common/test/samples/format/LocalDateFormatSamples.kt
+++ b/core/common/test/samples/format/LocalDateFormatSamples.kt
@@ -26,6 +26,46 @@ class LocalDateFormatSamples {
     }
 
     @Test
+    fun ordinalDay() {
+        // Using ordinal day with the default English‑suffix formatter
+        val defaultOrdinalDays = LocalDate.Format {
+            dayOrdinal(DayOrdinalNames.ENGLISH); char(' '); monthName(MonthNames.ENGLISH_ABBREVIATED)
+        }
+        check(defaultOrdinalDays.format(LocalDate(2021, 1, 1)) == "1st Jan")
+        check(defaultOrdinalDays.format(LocalDate(2021, 1, 2)) == "2nd Jan")
+        check(defaultOrdinalDays.format(LocalDate(2021, 1, 3)) == "3rd Jan")
+        check(defaultOrdinalDays.format(LocalDate(2021, 1, 4)) == "4th Jan")
+        check(defaultOrdinalDays.format(LocalDate(2021, 1, 11)) == "11th Jan")
+        check(defaultOrdinalDays.format(LocalDate(2021, 1, 21)) == "21st Jan")
+        check(defaultOrdinalDays.format(LocalDate(2021, 1, 22)) == "22nd Jan")
+        check(defaultOrdinalDays.format(LocalDate(2021, 1, 31)) == "31st Jan")
+    }
+
+    @Test
+    fun ordinalDayWithCustomNames() {
+        // Using ordinal day with a custom formatter that always falls back to "th"
+        val customOrdinalDays = LocalDate.Format {
+            dayOrdinal(
+                names = DayOrdinalNames(
+                    List(31) {
+                        val d = it + 1
+                        when (d) {
+                            1 -> "1st"
+                            2 -> "2nd"
+                            3 -> "3rd"
+                            else -> "${d}th"
+                        }
+                    }
+                )); char(' '); monthName(MonthNames.ENGLISH_ABBREVIATED)
+        }
+        check(customOrdinalDays.format(LocalDate(2021, 1, 1)) == "1st Jan")
+        check(customOrdinalDays.format(LocalDate(2021, 1, 2)) == "2nd Jan")
+        check(customOrdinalDays.format(LocalDate(2021, 1, 3)) == "3rd Jan")
+        check(customOrdinalDays.format(LocalDate(2021, 1, 22)) == "22th Jan")
+        check(customOrdinalDays.format(LocalDate(2021, 1, 31)) == "31th Jan")
+    }
+
+    @Test
     fun dayOfWeek() {
         // Using strings for day-of-week names in a custom format
         val format = LocalDate.Format {

--- a/core/common/test/samples/format/LocalDateFormatSamples.kt
+++ b/core/common/test/samples/format/LocalDateFormatSamples.kt
@@ -138,7 +138,7 @@ class LocalDateFormatSamples {
         }
     }
 
-    class DayOrdinalSamples {
+    class DayOrdinalNamesSamples {
         @Test
         fun usage() {
             // Using ordinal day with the default English‑suffix formatter
@@ -149,7 +149,7 @@ class LocalDateFormatSamples {
         }
 
         @Test
-        fun ordinalDayWithCustomNames() {
+        fun customNames() {
             // Using ordinal day with a custom formatter that always falls back to "th"
             val customOrdinalDays = LocalDate.Format {
                 dayOrdinal(

--- a/core/common/test/samples/format/LocalDateFormatSamples.kt
+++ b/core/common/test/samples/format/LocalDateFormatSamples.kt
@@ -5,9 +5,10 @@
 
 package kotlinx.datetime.test.samples.format
 
-import kotlinx.datetime.*
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.format.*
-import kotlin.test.*
+import kotlin.test.Test
 
 class LocalDateFormatSamples {
     @Test
@@ -39,30 +40,6 @@ class LocalDateFormatSamples {
         check(defaultOrdinalDays.format(LocalDate(2021, 1, 21)) == "21st Jan")
         check(defaultOrdinalDays.format(LocalDate(2021, 1, 22)) == "22nd Jan")
         check(defaultOrdinalDays.format(LocalDate(2021, 1, 31)) == "31st Jan")
-    }
-
-    @Test
-    fun ordinalDayWithCustomNames() {
-        // Using ordinal day with a custom formatter that always falls back to "th"
-        val customOrdinalDays = LocalDate.Format {
-            dayOrdinal(
-                names = DayOrdinalNames(
-                    List(31) {
-                        val d = it + 1
-                        when (d) {
-                            1 -> "1st"
-                            2 -> "2nd"
-                            3 -> "3rd"
-                            else -> "${d}th"
-                        }
-                    }
-                )); char(' '); monthName(MonthNames.ENGLISH_ABBREVIATED)
-        }
-        check(customOrdinalDays.format(LocalDate(2021, 1, 1)) == "1st Jan")
-        check(customOrdinalDays.format(LocalDate(2021, 1, 2)) == "2nd Jan")
-        check(customOrdinalDays.format(LocalDate(2021, 1, 3)) == "3rd Jan")
-        check(customOrdinalDays.format(LocalDate(2021, 1, 22)) == "22th Jan")
-        check(customOrdinalDays.format(LocalDate(2021, 1, 31)) == "31th Jan")
     }
 
     @Test
@@ -131,9 +108,11 @@ class LocalDateFormatSamples {
         @Test
         fun names() {
             // Obtaining the list of day of week names
-            check(DayOfWeekNames.ENGLISH_ABBREVIATED.names == listOf(
-                "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"
-            ))
+            check(
+                DayOfWeekNames.ENGLISH_ABBREVIATED.names == listOf(
+                    "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"
+                )
+            )
         }
 
         @Test
@@ -156,6 +135,66 @@ class LocalDateFormatSamples {
                 dayOfWeek(DayOfWeekNames.ENGLISH_ABBREVIATED)
             }
             check(format.format(LocalDate(2021, 1, 13)) == "2021-01-13, Wed")
+        }
+    }
+
+    class DayOrdinalSamples {
+        @Test
+        fun usage() {
+            // Using ordinal day with the default English‑suffix formatter
+            val format = LocalDate.Format {
+                dayOrdinal(DayOrdinalNames.ENGLISH); char(' '); monthName(MonthNames.ENGLISH_ABBREVIATED)
+            }
+            check(format.format(LocalDate(2021, 1, 13)) == "2021-01-13, Wed")
+        }
+
+        @Test
+        fun ordinalDayWithCustomNames() {
+            // Using ordinal day with a custom formatter that always falls back to "th"
+            val customOrdinalDays = LocalDate.Format {
+                dayOrdinal(
+                    names = DayOrdinalNames(
+                        List(31) {
+                            val d = it + 1
+                            when (d) {
+                                1 -> "1st"
+                                2 -> "2nd"
+                                3 -> "3rd"
+                                else -> "${d}th"
+                            }
+                        }
+                    )); char(' '); monthName(MonthNames.ENGLISH_ABBREVIATED)
+            }
+            check(customOrdinalDays.format(LocalDate(2021, 1, 1)) == "1st Jan")
+            check(customOrdinalDays.format(LocalDate(2021, 1, 2)) == "2nd Jan")
+            check(customOrdinalDays.format(LocalDate(2021, 1, 3)) == "3rd Jan")
+            check(customOrdinalDays.format(LocalDate(2021, 1, 22)) == "22th Jan")
+            check(customOrdinalDays.format(LocalDate(2021, 1, 31)) == "31th Jan")
+        }
+
+        @Test
+        fun names() {
+            // Obtaining the list of day of week names
+            check(
+                DayOrdinalNames.ENGLISH.names == listOf(
+                    "1st", "2nd", "3rd", "4th", "5th", "6th", "7th",
+                    "8th", "9th", "10th", "11th", "12th", "13th",
+                    "14th", "15th", "16th", "17th", "18th", "19th",
+                    "20th", "21st", "22nd", "23rd", "24th", "25th",
+                    "26th", "27th", "28th", "29th", "30th", "31st"
+                )
+            )
+        }
+
+        @Test
+        fun invalidListSize() {
+            // Attempting to create a DayOrdinalNames with an invalid list size
+            try {
+                DayOrdinalNames(listOf("1st", "2nd", "3rd")) // only 3 names, should throw
+                check(false) // should not reach here
+            } catch (e: Throwable) {
+                check(e is IllegalArgumentException)
+            }
         }
     }
 }


### PR DESCRIPTION
This PR introduces support for formatting day-of-month ordinal numbers (e.g., "1st", "2nd").
#559 
### Feature Addition: Day-of-Month Ordinal Formatting
* Added `dayOrdinal` method to `DateTimeFormatBuilder` for formatting ordinal day numbers using the customizable `DayOrdinalNames`.
* The `DayOrdinalNames` is used to define the list of ordinal day names, with validation ensuring exactly 31 elements, and a predefined `ENGLISH` instance. 
* Introduced `OrdinalDayDirective`.
* Added test coverage for the new functionalities.