### PR TITLE
Fill Implementation-Title/Version/Vendor attributes in JAR's Manifest

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -278,6 +278,7 @@ tasks {
         // Also ensure that the module path is used instead of classpath.
         classpath = compileKotlinJvm.libraries
         modularity.inferModulePath.set(true)
+        options.javaModuleVersion.set(project.version.toString().takeUnless { it == Project.DEFAULT_VERSION })
     }
 
     // Configure the JAR task so that it will include the compiled module-info class file.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -283,7 +283,12 @@ tasks {
     // Configure the JAR task so that it will include the compiled module-info class file.
     val jvmJar by existing(Jar::class) {
         manifest {
-            attributes("Multi-Release" to true)
+            attributes(
+                "Multi-Release" to true,
+                "Implementation-Vendor" to "JetBrains",
+                "Implementation-Title" to project.name,
+                "Implementation-Version" to project.version,
+            )
         }
         from(compileJavaModuleInfo.map { it.destinationDirectory }) {
             into("META-INF/versions/9/")


### PR DESCRIPTION
#592

MANIFEST.MF:
```
Manifest-Version: 1.0
Multi-Release: true
Implementation-Vendor: JetBrains
Implementation-Title: kotlinx-datetime
Implementation-Version: 0.7.1-SNAPSHOT
```