### PR TITLE
Update KDoc to explicitly refer to kotlin.time.Instant

### DIFF
--- a/core/common/src/DateTimePeriod.kt
+++ b/core/common/src/DateTimePeriod.kt
@@ -17,7 +17,7 @@ import kotlin.time.Duration
 import kotlinx.serialization.Serializable
 
 /**
- * A difference between two [instants][Instant], decomposed into date and time components.
+ * A difference between two [instants][kotlin.time.Instant], decomposed into date and time components.
  *
  * The date components are: [years] ([DateTimeUnit.YEAR]), [months] ([DateTimeUnit.MONTH]), and [days] ([DateTimeUnit.DAY]).
  *

--- a/core/common/src/LocalDate.kt
+++ b/core/common/src/LocalDate.kt
@@ -22,7 +22,8 @@ import kotlin.internal.*
  * as [LocalDate.periodUntil] and various other [*until][LocalDate.daysUntil] functions.
  *
  * The range of supported years is at least enough to represent dates of all instants between
- * [Instant.DISTANT_PAST] and [Instant.DISTANT_FUTURE].
+ * [Instant.DISTANT_PAST][kotlin.time.Instant.DISTANT_PAST]
+ * and [Instant.DISTANT_FUTURE][kotlin.time.Instant.DISTANT_FUTURE].
  *
  * ### Arithmetic operations
  *
@@ -36,7 +37,8 @@ import kotlin.internal.*
  * ### Platform specifics
  *
  * The range of supported years is unspecified, but at least is enough to represent dates of all instants between
- * [Instant.DISTANT_PAST] and [Instant.DISTANT_FUTURE].
+ * [Instant.DISTANT_PAST][kotlin.time.Instant.DISTANT_PAST]
+ * and [Instant.DISTANT_FUTURE][kotlin.time.Instant.DISTANT_FUTURE].
  *
  * On the JVM,
  * there are `LocalDate.toJavaLocalDate()` and `java.time.LocalDate.toKotlinLocalDate()`
@@ -174,7 +176,8 @@ public expect class LocalDate : Comparable<LocalDate> {
      *
      * The supported ranges of components:
      * - [year] the range is at least enough to represent dates of all instants between
-     *          [Instant.DISTANT_PAST] and [Instant.DISTANT_FUTURE]
+     *          [Instant.DISTANT_PAST][kotlin.time.Instant.DISTANT_PAST]
+     *          and [Instant.DISTANT_FUTURE][kotlin.time.Instant.DISTANT_FUTURE]
      * - [month] `1..12`
      * - [day] `1..31`, the upper bound can be less, depending on the month
      *
@@ -189,7 +192,8 @@ public expect class LocalDate : Comparable<LocalDate> {
      *
      * The supported ranges of components:
      * - [year] the range at least is enough to represent dates of all instants between
-     *          [Instant.DISTANT_PAST] and [Instant.DISTANT_FUTURE]
+     *          [Instant.DISTANT_PAST][kotlin.time.Instant.DISTANT_PAST]
+     *          and [Instant.DISTANT_FUTURE][kotlin.time.Instant.DISTANT_FUTURE]
      * - [month] all values of the [Month] enum
      * - [day] `1..31`, the upper bound can be less, depending on the month
      *

--- a/core/common/src/LocalDateTime.kt
+++ b/core/common/src/LocalDateTime.kt
@@ -17,15 +17,16 @@ import kotlin.jvm.JvmName
 /**
  * The representation of a specific civil date and time without a reference to a particular time zone.
  *
- * This class does not describe specific *moments in time*. For that, use [Instant] values instead.
+ * This class does not describe specific *moments in time*. For that, use [Instant][kotlin.time.Instant] values instead.
  * Instead, you can think of its instances as clock readings, which can be observed in a particular time zone.
  * For example, `2020-08-30T18:43` is not a *moment in time* since someone in Berlin and Tokyo would witness
  * this on their clocks at different times, but it is a [LocalDateTime].
  *
- * The main purpose of this class is to provide human-readable representations of [Instant] values, to transfer them
- * as data, or to define future planned events that will have the same local datetime even if the time zone rules
- * change.
- * In all other cases, when a specific time zone is known, it is recommended to use [Instant] instead.
+ * The main purpose of this class is to provide human-readable representations of [Instant][kotlin.time.Instant] values,
+ * to transfer them as data, or to define future planned events that will have the same local datetime
+ * even if the time zone rules change.
+ * In all other cases, when a specific time zone is known,
+ * it is recommended to use [Instant][kotlin.time.Instant] instead.
  *
  * ### Arithmetic operations
  *
@@ -48,7 +49,8 @@ import kotlin.jvm.JvmName
  * It provides well-defined date arithmetic.
  *
  * If the time component must be taken into account, [LocalDateTime]
- * should be converted to [Instant] using a specific time zone, and the arithmetic on [Instant] should be used.
+ * should be converted to [Instant][kotlin.time.Instant] using a specific time zone,
+ * and the arithmetic on [Instant][kotlin.time.Instant] should be used.
  *
  * ```
  * val timeZone = TimeZone.of("Europe/Berlin")
@@ -81,8 +83,8 @@ import kotlin.jvm.JvmName
  * from constructing such a [LocalDateTime].
  * Before using a [LocalDateTime] constructed using any API,
  * please ensure that the result is valid in the implied time zone.
- * The recommended pattern is to convert a [LocalDateTime] to [Instant] as soon as possible (see
- * [LocalDateTime.toInstant]) and work with [Instant] values instead.
+ * The recommended pattern is to convert a [LocalDateTime] to [Instant][kotlin.time.Instant] as soon as possible (see
+ * [LocalDateTime.toInstant]) and work with [Instant][kotlin.time.Instant] values instead.
  *
  * [LocalDateTime] can be constructed directly from its components, [LocalDate] and [LocalTime], using the constructor.
  * See sample 1.
@@ -104,7 +106,7 @@ import kotlin.jvm.JvmName
  *
  * @see LocalDate for only the date part of the datetime value.
  * @see LocalTime for only the time part of the datetime value.
- * @see Instant for the representation of a specific moment in time independent of a time zone.
+ * @see kotlin.time.Instant for the representation of a specific moment in time independent of a time zone.
  * @sample kotlinx.datetime.test.samples.LocalDateTimeSamples.fromDateAndTime
  * @sample kotlinx.datetime.test.samples.LocalDateTimeSamples.alternativeConstruction
  * @sample kotlinx.datetime.test.samples.LocalDateTimeSamples.simpleParsingAndFormatting
@@ -352,7 +354,8 @@ public expect class LocalDateTime : Comparable<LocalDateTime> {
      * a negative number if this value represents earlier civil time than the other,
      * and a positive number if this value represents later civil time than the other.
      *
-     * **Pitfall**: comparing [LocalDateTime] values is less robust than comparing [Instant] values.
+     * **Pitfall**: comparing [LocalDateTime] values is less robust than comparing
+     * [Instant][kotlin.time.Instant] values.
      * Consider the following situation, where a later moment in time corresponds to an earlier [LocalDateTime] value:
      * ```
      * val zone = TimeZone.of("Europe/Berlin")

--- a/core/common/src/LocalTime.kt
+++ b/core/common/src/LocalTime.kt
@@ -35,7 +35,7 @@ import kotlin.jvm.JvmName
  * Arithmetic operations on [LocalTime] are not provided because they are not well-defined without a date and
  * a time zone.
  * See [LocalDateTime] for an explanation of why not accounting for time zone transitions may lead to incorrect results.
- * To perform arithmetic operations on time values, first, obtain an [Instant].
+ * To perform arithmetic operations on time values, first, obtain an [Instant][kotlin.time.Instant].
  *
  * ```
  * val time = LocalTime(13, 30)
@@ -46,7 +46,7 @@ import kotlin.jvm.JvmName
  * ```
  *
  * Since this pattern is extremely verbose and difficult to get right, it is recommended to work exclusively
- * with [Instant] and only obtain a [LocalTime] when displaying the time to the user.
+ * with [Instant][kotlin.time.Instant] and only obtain a [LocalTime] when displaying the time to the user.
  *
  * ### Platform specifics
  *
@@ -112,7 +112,7 @@ public expect class LocalTime : Comparable<LocalTime> {
          * the number of seconds that have physically elapsed since the start of the day.
          * The reason is that, due to daylight-saving-time transitions, the number of seconds since the start
          * of the day is not a constant value: clocks could be shifted by an hour or more on some dates.
-         * Use [Instant] to perform reliable time arithmetic.
+         * Use [Instant][kotlin.time.Instant] to perform reliable time arithmetic.
          *
          * @see LocalTime.toSecondOfDay
          * @see LocalTime.fromMillisecondOfDay
@@ -133,7 +133,7 @@ public expect class LocalTime : Comparable<LocalTime> {
          * the number of milliseconds that have physically elapsed since the start of the day.
          * The reason is that, due to daylight-saving-time transitions, the number of milliseconds since the start
          * of the day is not a constant value: clocks could be shifted by an hour or more on some dates.
-         * Use [Instant] to perform reliable time arithmetic.
+         * Use [Instant][kotlin.time.Instant] to perform reliable time arithmetic.
          *
          * @see LocalTime.fromSecondOfDay
          * @see LocalTime.toMillisecondOfDay
@@ -153,7 +153,7 @@ public expect class LocalTime : Comparable<LocalTime> {
          * the number of nanoseconds that have physically elapsed since the start of the day.
          * The reason is that, due to daylight-saving-time transitions, the number of nanoseconds since the start
          * of the day is not a constant value: clocks could be shifted by an hour or more on some dates.
-         * Use [Instant] to perform reliable time arithmetic.
+         * Use [Instant][kotlin.time.Instant] to perform reliable time arithmetic.
          *
          * @see LocalTime.fromSecondOfDay
          * @see LocalTime.fromMillisecondOfDay
@@ -269,7 +269,7 @@ public expect class LocalTime : Comparable<LocalTime> {
      * For example, `LocalTime(4, 0).toMillisecondOfDay()` will return `4 * 60 * 60`, the four hours
      * worth of seconds, but because of DST transitions, when clocks show 4:00, in fact, three, four, five, or
      * some other number of hours could have passed since the day started.
-     * Use [Instant] to perform reliable time arithmetic.
+     * Use [Instant][kotlin.time.Instant] to perform reliable time arithmetic.
      *
      * @see toMillisecondOfDay
      * @see toNanosecondOfDay
@@ -285,7 +285,7 @@ public expect class LocalTime : Comparable<LocalTime> {
      * For example, `LocalTime(4, 0).toMillisecondOfDay()` will return `4 * 60 * 60 * 1_000`, the four hours
      * worth of milliseconds, but because of DST transitions, when clocks show 4:00, in fact, three, four, five, or
      * some other number of hours could have passed since the day started.
-     * Use [Instant] to perform reliable time arithmetic.
+     * Use [Instant][kotlin.time.Instant] to perform reliable time arithmetic.
      *
      * @see toSecondOfDay
      * @see toNanosecondOfDay
@@ -301,7 +301,7 @@ public expect class LocalTime : Comparable<LocalTime> {
      * For example, `LocalTime(4, 0).toMillisecondOfDay()` will return `4 * 60 * 60 * 1_000_000_000`, the four hours
      * worth of nanoseconds, but because of DST transitions, when clocks show 4:00, in fact, three, four, five, or
      * some other number of hours could have passed since the day started.
-     * Use [Instant] to perform reliable time arithmetic.
+     * Use [Instant][kotlin.time.Instant] to perform reliable time arithmetic.
      *
      * @see toMillisecondOfDay
      * @see toNanosecondOfDay

--- a/core/common/src/YearMonth.kt
+++ b/core/common/src/YearMonth.kt
@@ -30,7 +30,8 @@ import kotlinx.serialization.Serializable
  * ### Platform specifics
  *
  * The range of supported years is unspecified, but at least is enough to represent year-months of all instants
- * between [Instant.DISTANT_PAST] and [Instant.DISTANT_FUTURE] in any time zone.
+ * between [Instant.DISTANT_PAST][kotlin.time.Instant.DISTANT_PAST]
+ * and [Instant.DISTANT_FUTURE][kotlin.time.Instant.DISTANT_FUTURE] in any time zone.
  *
  * On the JVM,
  * there are `YearMonth.toJavaYearMonth()` and `java.time.YearMonth.toKotlinYearMonth()`
@@ -67,7 +68,8 @@ public expect class YearMonth
  *
  * The supported ranges of components:
  * - [year] the range is unspecified, but at least is enough to represent year-months of all instants between
- *          [Instant.DISTANT_PAST] and [Instant.DISTANT_FUTURE] in any time zone.
+ *          [Instant.DISTANT_PAST][kotlin.time.Instant.DISTANT_PAST]
+ *          and [Instant.DISTANT_FUTURE][kotlin.time.Instant.DISTANT_FUTURE] in any time zone.
  * - [month] `1..12`
  *
  * @throws IllegalArgumentException if any parameter is out of range.
@@ -122,7 +124,8 @@ public constructor(year: Int, month: Int) : Comparable<YearMonth> {
      * Constructs a [YearMonth] instance from the given year-month components.
      *
      * The range for [year] is unspecified, but at least is enough to represent year-months of all instants
-     * between [Instant.DISTANT_PAST] and [Instant.DISTANT_FUTURE] in any time zone.
+     * between [Instant.DISTANT_PAST][kotlin.time.Instant.DISTANT_PAST]
+     * and [Instant.DISTANT_FUTURE][kotlin.time.Instant.DISTANT_FUTURE] in any time zone.
      *
      * @throws IllegalArgumentException if [year] is out of range.
      * @sample kotlinx.datetime.test.samples.YearMonthSamples.constructorFunction


### PR DESCRIPTION
If `kotlin.time.Instant` is not explicitly imported in a source file, all references to it in KDoc are resolved to `kotlinx.datetime.Instant`.
This change fixes references to explicitly point to a correct class.

#599 fixed