### PR TITLE
Simplify the deprecated Instant logic

### DIFF
--- a/core/api/kotlinx-datetime.api
+++ b/core/api/kotlinx-datetime.api
@@ -248,21 +248,21 @@ public final class kotlinx/datetime/Instant$Companion {
 
 public final class kotlinx/datetime/InstantJvmKt {
 	public static final fun minus (Lkotlin/time/Instant;ILkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlin/time/Instant;
-	public static final fun minus (Lkotlinx/datetime/Instant;ILkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final synthetic fun minus (Lkotlinx/datetime/Instant;ILkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
 	public static final fun periodUntil (Lkotlin/time/Instant;Lkotlin/time/Instant;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/DateTimePeriod;
-	public static final fun periodUntil (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/DateTimePeriod;
+	public static final synthetic fun periodUntil (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/DateTimePeriod;
 	public static final fun plus (Lkotlin/time/Instant;ILkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlin/time/Instant;
 	public static final fun plus (Lkotlin/time/Instant;JLkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlin/time/Instant;
 	public static final fun plus (Lkotlin/time/Instant;JLkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlin/time/Instant;
 	public static final fun plus (Lkotlin/time/Instant;Lkotlinx/datetime/DateTimePeriod;Lkotlinx/datetime/TimeZone;)Lkotlin/time/Instant;
 	public static final fun plus (Lkotlin/time/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlin/time/Instant;
-	public static final fun plus (Lkotlinx/datetime/Instant;ILkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
-	public static final fun plus (Lkotlinx/datetime/Instant;JLkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlinx/datetime/Instant;
-	public static final fun plus (Lkotlinx/datetime/Instant;JLkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
-	public static final fun plus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimePeriod;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
-	public static final fun plus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final synthetic fun plus (Lkotlinx/datetime/Instant;ILkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final synthetic fun plus (Lkotlinx/datetime/Instant;JLkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlinx/datetime/Instant;
+	public static final synthetic fun plus (Lkotlinx/datetime/Instant;JLkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final synthetic fun plus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimePeriod;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final synthetic fun plus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
 	public static final fun until (Lkotlin/time/Instant;Lkotlin/time/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)J
-	public static final fun until (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)J
+	public static final synthetic fun until (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)J
 }
 
 public final class kotlinx/datetime/InstantKt {
@@ -285,6 +285,7 @@ public final class kotlinx/datetime/InstantKt {
 	public static final fun minus (Lkotlin/time/Instant;Lkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlin/time/Instant;
 	public static final fun minus (Lkotlin/time/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlin/time/Instant;
 	public static final fun minus (Lkotlinx/datetime/Instant;ILkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlinx/datetime/Instant;
+	public static final fun minus (Lkotlinx/datetime/Instant;ILkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
 	public static final fun minus (Lkotlinx/datetime/Instant;JLkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlinx/datetime/Instant;
 	public static final fun minus (Lkotlinx/datetime/Instant;JLkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
 	public static final fun minus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimePeriod;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
@@ -297,6 +298,7 @@ public final class kotlinx/datetime/InstantKt {
 	public static final fun monthsUntil (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/TimeZone;)I
 	public static final fun parse (Lkotlin/time/Instant$Companion;Ljava/lang/CharSequence;Lkotlinx/datetime/format/DateTimeFormat;)Lkotlin/time/Instant;
 	public static final fun periodUntil (Lkotlin/time/Instant;Lkotlin/time/Instant;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/DateTimePeriod;
+	public static final fun periodUntil (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/DateTimePeriod;
 	public static final fun plus (Lkotlin/time/Instant;ILkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlin/time/Instant;
 	public static final fun plus (Lkotlin/time/Instant;ILkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlin/time/Instant;
 	public static final fun plus (Lkotlin/time/Instant;JLkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlin/time/Instant;
@@ -305,13 +307,19 @@ public final class kotlinx/datetime/InstantKt {
 	public static final fun plus (Lkotlin/time/Instant;Lkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlin/time/Instant;
 	public static final fun plus (Lkotlin/time/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlin/time/Instant;
 	public static final fun plus (Lkotlinx/datetime/Instant;ILkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlinx/datetime/Instant;
+	public static final fun plus (Lkotlinx/datetime/Instant;ILkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final fun plus (Lkotlinx/datetime/Instant;JLkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlinx/datetime/Instant;
+	public static final fun plus (Lkotlinx/datetime/Instant;JLkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
+	public static final fun plus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimePeriod;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
 	public static final fun plus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit$TimeBased;)Lkotlinx/datetime/Instant;
+	public static final fun plus (Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
 	public static final fun toDeprecatedInstant (Lkotlin/time/Instant;)Lkotlinx/datetime/Instant;
 	public static final fun toInstant (Ljava/lang/String;)Lkotlinx/datetime/Instant;
 	public static final fun toStdlibInstant (Lkotlinx/datetime/Instant;)Lkotlin/time/Instant;
 	public static final fun until (Lkotlin/time/Instant;Lkotlin/time/Instant;Lkotlinx/datetime/DateTimeUnit$TimeBased;)J
 	public static final fun until (Lkotlin/time/Instant;Lkotlin/time/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)J
 	public static final fun until (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit$TimeBased;)J
+	public static final fun until (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/DateTimeUnit;Lkotlinx/datetime/TimeZone;)J
 	public static final fun yearsUntil (Lkotlin/time/Instant;Lkotlin/time/Instant;Lkotlinx/datetime/TimeZone;)I
 	public static final fun yearsUntil (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/TimeZone;)I
 }

--- a/core/common/src/DeprecatedInstant.kt
+++ b/core/common/src/DeprecatedInstant.kt
@@ -349,7 +349,8 @@ public fun String.toInstant(): Instant = Instant.parse(this)
     level = DeprecationLevel.WARNING,
     replaceWith = ReplaceWith("this.toStdlibInstant().plus(period, timeZone).toDeprecatedInstant()")
 )
-public expect fun Instant.plus(period: DateTimePeriod, timeZone: TimeZone): Instant
+public fun Instant.plus(period: DateTimePeriod, timeZone: TimeZone): Instant =
+    toStdlibInstant().plus(period, timeZone).toDeprecatedInstant()
 
 /**
  * Returns an instant that is the result of subtracting components of [DateTimePeriod] from this instant. The components
@@ -399,7 +400,8 @@ public fun Instant.minus(period: DateTimePeriod, timeZone: TimeZone): Instant =
     level = DeprecationLevel.WARNING,
     replaceWith = ReplaceWith("this.toStdlibInstant().periodUntil(other.toStdlibInstant(), timeZone)")
 )
-public expect fun Instant.periodUntil(other: Instant, timeZone: TimeZone): DateTimePeriod
+public fun Instant.periodUntil(other: Instant, timeZone: TimeZone): DateTimePeriod =
+    toStdlibInstant().periodUntil(other.toStdlibInstant(), timeZone)
 
 /**
  * Returns the whole number of the specified date or time [units][unit] between `this` and [other] instants
@@ -419,7 +421,8 @@ public expect fun Instant.periodUntil(other: Instant, timeZone: TimeZone): DateT
     level = DeprecationLevel.WARNING,
     replaceWith = ReplaceWith("this.toStdlibInstant().until(other.toStdlibInstant(), unit, timeZone)")
 )
-public expect fun Instant.until(other: Instant, unit: DateTimeUnit, timeZone: TimeZone): Long
+public fun Instant.until(other: Instant, unit: DateTimeUnit, timeZone: TimeZone): Long =
+    toStdlibInstant().until(other.toStdlibInstant(), unit, timeZone)
 
 /**
  * Returns the whole number of the specified time [units][unit] between `this` and [other] instants.
@@ -529,7 +532,8 @@ public fun Instant.minus(other: Instant, timeZone: TimeZone): DateTimePeriod =
     level = DeprecationLevel.WARNING,
     replaceWith = ReplaceWith("this.toStdlibInstant().plus(1, unit, timeZone).toDeprecatedInstant()")
 )
-public expect fun Instant.plus(unit: DateTimeUnit, timeZone: TimeZone): Instant
+public fun Instant.plus(unit: DateTimeUnit, timeZone: TimeZone): Instant =
+    toStdlibInstant().plus(1, unit, timeZone).toDeprecatedInstant()
 
 /**
  * Returns an instant that is the result of subtracting one [unit] from this instant
@@ -591,7 +595,8 @@ public fun Instant.minus(unit: DateTimeUnit.TimeBased): Instant =
     level = DeprecationLevel.WARNING,
     replaceWith = ReplaceWith("this.toStdlibInstant().plus(value, unit, timeZone).toDeprecatedInstant()")
 )
-public expect fun Instant.plus(value: Int, unit: DateTimeUnit, timeZone: TimeZone): Instant
+public fun Instant.plus(value: Int, unit: DateTimeUnit, timeZone: TimeZone): Instant =
+    toStdlibInstant().plus(value, unit, timeZone).toDeprecatedInstant()
 
 /**
  * Returns an instant that is the result of subtracting the [value] number of the specified [unit] from this instant
@@ -613,7 +618,8 @@ public expect fun Instant.plus(value: Int, unit: DateTimeUnit, timeZone: TimeZon
     level = DeprecationLevel.WARNING,
     replaceWith = ReplaceWith("this.toStdlibInstant().minus(value, unit, timeZone).toDeprecatedInstant()")
 )
-public expect fun Instant.minus(value: Int, unit: DateTimeUnit, timeZone: TimeZone): Instant
+public fun Instant.minus(value: Int, unit: DateTimeUnit, timeZone: TimeZone): Instant =
+    toStdlibInstant().minus(value, unit, timeZone).toDeprecatedInstant()
 
 /**
  * Returns an instant that is the result of adding the [value] number of the specified [unit] to this instant.
@@ -666,7 +672,8 @@ public fun Instant.minus(value: Int, unit: DateTimeUnit.TimeBased): Instant =
     level = DeprecationLevel.WARNING,
     replaceWith = ReplaceWith("this.toStdlibInstant().plus(value, unit, timeZone).toDeprecatedInstant()")
 )
-public expect fun Instant.plus(value: Long, unit: DateTimeUnit, timeZone: TimeZone): Instant
+public fun Instant.plus(value: Long, unit: DateTimeUnit, timeZone: TimeZone): Instant =
+    toStdlibInstant().plus(value, unit, timeZone).toDeprecatedInstant()
 
 /**
  * Returns an instant that is the result of subtracting the [value] number of the specified [unit] from this instant
@@ -706,7 +713,8 @@ public fun Instant.minus(value: Long, unit: DateTimeUnit, timeZone: TimeZone): I
     level = DeprecationLevel.WARNING,
     replaceWith = ReplaceWith("this.toStdlibInstant().plus(value, unit).toDeprecatedInstant()")
 )
-public expect fun Instant.plus(value: Long, unit: DateTimeUnit.TimeBased): Instant
+public fun Instant.plus(value: Long, unit: DateTimeUnit.TimeBased): Instant =
+    toStdlibInstant().plus(value, unit).toDeprecatedInstant()
 
 /**
  * Returns an instant that is the result of subtracting the [value] number of the specified [unit] from this instant.

--- a/core/commonKotlin/src/DeprecatedInstant.kt
+++ b/core/commonKotlin/src/DeprecatedInstant.kt
@@ -205,59 +205,6 @@ public actual class Instant internal constructor(
 
 }
 
-@Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("this.toStdlibInstant().plus(period, timeZone).toDeprecatedInstant()")
-)
-public actual fun Instant.plus(period: DateTimePeriod, timeZone: TimeZone): Instant =
-    toStdlibInstant().plus(period, timeZone).toDeprecatedInstant()
-
-@Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("this.toStdlibInstant().plus(1, unit, timeZone).toDeprecatedInstant()")
-)
-public actual fun Instant.plus(unit: DateTimeUnit, timeZone: TimeZone): Instant =
-    plus(1L, unit, timeZone)
-@Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("this.toStdlibInstant().plus(value, unit, timeZone).toDeprecatedInstant()")
-)
-public actual fun Instant.plus(value: Int, unit: DateTimeUnit, timeZone: TimeZone): Instant =
-    plus(value.toLong(), unit, timeZone)
-@Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("this.toStdlibInstant().minus(value, unit, timeZone).toDeprecatedInstant()")
-)
-public actual fun Instant.minus(value: Int, unit: DateTimeUnit, timeZone: TimeZone): Instant =
-    plus(-value.toLong(), unit, timeZone)
-@Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("this.toStdlibInstant().plus(value, unit, timeZone).toDeprecatedInstant()")
-)
-public actual fun Instant.plus(value: Long, unit: DateTimeUnit, timeZone: TimeZone): Instant =
-    toStdlibInstant().plus(value, unit, timeZone).toDeprecatedInstant()
-
-@Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("this.toStdlibInstant().plus(value, unit).toDeprecatedInstant()")
-)
-public actual fun Instant.plus(value: Long, unit: DateTimeUnit.TimeBased): Instant =
-    toStdlibInstant().plus(value, unit).toDeprecatedInstant()
-
-@Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("this.toStdlibInstant().periodUntil(other.toStdlibInstant(), timeZone)")
-)
-public actual fun Instant.periodUntil(other: Instant, timeZone: TimeZone): DateTimePeriod =
-    toStdlibInstant().periodUntil(other.toStdlibInstant(), timeZone)
-
-@Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("this.toStdlibInstant().until(other.toStdlibInstant(), unit, timeZone)")
-)
-public actual fun Instant.until(other: Instant, unit: DateTimeUnit, timeZone: TimeZone): Long =
-    toStdlibInstant().until(other.toStdlibInstant(), unit, timeZone)
-
 
 private val ISO_DATE_TIME_OFFSET_WITH_TRAILING_ZEROS = DateTimeComponents.Format {
     date(ISO_DATE)

--- a/core/darwin/test/TimeZoneNativeTest.kt
+++ b/core/darwin/test/TimeZoneNativeTest.kt
@@ -5,23 +5,9 @@
 
 package kotlinx.datetime.test
 
-import kotlinx.datetime.DateTimePeriod
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.internal.OffsetInfo
-import kotlinx.datetime.internal.TimeZoneRulesFoundation
-import kotlinx.datetime.internal.TzdbOnFilesystem
-import kotlinx.datetime.internal.getAvailableZoneIds
-import kotlinx.datetime.internal.getAvailableZoneIdsFoundation
-import kotlinx.datetime.internal.timeZoneById
-import kotlinx.datetime.internal.timeZoneByIdFoundation
-import kotlinx.datetime.offsetAt
-import kotlinx.datetime.plus
-import kotlinx.datetime.plusSeconds
-import kotlinx.datetime.toInstant
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
+import kotlinx.datetime.*
+import kotlinx.datetime.internal.*
+import kotlin.test.*
 import kotlinx.datetime.test.TimeZoneNativeTest.OffsetInfoType.*
 
 class TimeZoneNativeTest {

--- a/core/jvm/src/DeprecatedInstant.kt
+++ b/core/jvm/src/DeprecatedInstant.kt
@@ -105,7 +105,6 @@ public actual class Instant internal constructor(internal val value: java.time.I
         public actual fun fromEpochMilliseconds(epochMilliseconds: Long): Instant =
             Instant(java.time.Instant.ofEpochMilli(epochMilliseconds))
 
-        // TODO: implement a custom parser to 1) help DCE get rid of the formatting machinery 2) move Instant to stdlib
         public actual fun parse(input: CharSequence, format: DateTimeFormat<DateTimeComponents>): Instant = try {
             /**
              * Can't use built-in Java Time's handling of `Instant.parse` because it supports 24:00:00 and
@@ -140,114 +139,74 @@ public actual class Instant internal constructor(internal val value: java.time.I
     }
 }
 
-private fun Instant.atZone(zone: TimeZone): java.time.ZonedDateTime = try {
-    value.atZone(zone.zoneId)
-} catch (e: DateTimeException) {
-    throw DateTimeArithmeticException(e)
-}
-
 @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
+    level = DeprecationLevel.HIDDEN,
     replaceWith = ReplaceWith("this.toStdlibInstant().plus(period, timeZone).toDeprecatedInstant()")
 )
-public actual fun Instant.plus(period: DateTimePeriod, timeZone: TimeZone): Instant {
-    try {
-        val thisZdt = atZone(timeZone)
-        return with(period) {
-            thisZdt
-                .run { if (totalMonths != 0L) plusMonths(totalMonths) else this }
-                .run { if (days != 0) plusDays(days.toLong()) else this }
-                .run { if (totalNanoseconds != 0L) plusNanos(totalNanoseconds) else this }
-        }.toInstant().let(::Instant)
-    } catch (e: DateTimeException) {
-        throw DateTimeArithmeticException(e)
-    }
-}
+@PublishedApi
+@JvmName("plus")
+internal fun Instant.plusJvm(period: DateTimePeriod, timeZone: TimeZone): Instant =
+    toStdlibInstant().plus(period, timeZone).toDeprecatedInstant()
 
 @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
+    level = DeprecationLevel.HIDDEN,
     replaceWith = ReplaceWith("this.toStdlibInstant().plus(1, unit, timeZone).toDeprecatedInstant()")
 )
-public actual fun Instant.plus(unit: DateTimeUnit, timeZone: TimeZone): Instant =
-    plus(1L, unit, timeZone)
+@PublishedApi
+@JvmName("plus")
+internal fun Instant.plusJvm(unit: DateTimeUnit, timeZone: TimeZone): Instant =
+    toStdlibInstant().plus(unit, timeZone).toDeprecatedInstant()
 
 @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
+    level = DeprecationLevel.HIDDEN,
     replaceWith = ReplaceWith("this.toStdlibInstant().plus(value, unit, timeZone).toDeprecatedInstant()")
 )
-public actual fun Instant.plus(value: Int, unit: DateTimeUnit, timeZone: TimeZone): Instant =
-    plus(value.toLong(), unit, timeZone)
+@PublishedApi
+@JvmName("plus")
+internal fun Instant.plusJvm(value: Int, unit: DateTimeUnit, timeZone: TimeZone): Instant =
+    toStdlibInstant().plus(value, unit, timeZone).toDeprecatedInstant()
 
 @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
+    level = DeprecationLevel.HIDDEN,
     replaceWith = ReplaceWith("this.toStdlibInstant().minus(value, unit, timeZone).toDeprecatedInstant()")
 )
-public actual fun Instant.minus(value: Int, unit: DateTimeUnit, timeZone: TimeZone): Instant =
-    plus(-value.toLong(), unit, timeZone)
+@PublishedApi
+@JvmName("minus")
+internal fun Instant.minusJvm(value: Int, unit: DateTimeUnit, timeZone: TimeZone): Instant =
+    toStdlibInstant().minus(value, unit, timeZone).toDeprecatedInstant()
 
 @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
+    level = DeprecationLevel.HIDDEN,
     replaceWith = ReplaceWith("this.toStdlibInstant().plus(value, unit, timeZone).toDeprecatedInstant()")
 )
-public actual fun Instant.plus(value: Long, unit: DateTimeUnit, timeZone: TimeZone): Instant =
-    try {
-        val thisZdt = atZone(timeZone)
-        when (unit) {
-            is DateTimeUnit.TimeBased ->
-                plus(value, unit).value.also { it.atZone(timeZone.zoneId) }
-            is DateTimeUnit.DayBased ->
-                thisZdt.plusDays(safeMultiply(value, unit.days.toLong())).toInstant()
-            is DateTimeUnit.MonthBased ->
-                thisZdt.plusMonths(safeMultiply(value, unit.months.toLong())).toInstant()
-        }.let(::Instant)
-    } catch (e: Exception) {
-        if (e !is DateTimeException && e !is ArithmeticException) throw e
-        throw DateTimeArithmeticException("Instant $this cannot be represented as local date when adding $value $unit to it", e)
-    }
+@PublishedApi
+@JvmName("plus")
+internal fun Instant.plusJvm(value: Long, unit: DateTimeUnit, timeZone: TimeZone): Instant =
+    toStdlibInstant().plus(value, unit, timeZone).toDeprecatedInstant()
 
 @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
+    level = DeprecationLevel.HIDDEN,
     replaceWith = ReplaceWith("this.toStdlibInstant().plus(value, unit).toDeprecatedInstant()")
 )
-public actual fun Instant.plus(value: Long, unit: DateTimeUnit.TimeBased): Instant =
-    try {
-        multiplyAndDivide(value, unit.nanoseconds, NANOS_PER_ONE.toLong()).let { (d, r) ->
-            Instant(this.value.plusSeconds(d).plusNanos(r))
-        }
-    } catch (e: Exception) {
-        if (e !is DateTimeException && e !is ArithmeticException) throw e
-        if (value > 0) Instant.MAX else Instant.MIN
-    }
+@PublishedApi
+@JvmName("plus")
+internal fun Instant.plusJvm(value: Long, unit: DateTimeUnit.TimeBased): Instant =
+    toStdlibInstant().plus(value, unit).toDeprecatedInstant()
 
 @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
+    level = DeprecationLevel.HIDDEN,
     replaceWith = ReplaceWith("this.toStdlibInstant().periodUntil(other.toStdlibInstant(), timeZone)")
 )
-public actual fun Instant.periodUntil(other: Instant, timeZone: TimeZone): DateTimePeriod {
-    var thisZdt = this.atZone(timeZone)
-    val otherZdt = other.atZone(timeZone)
-
-    val months = thisZdt.until(otherZdt, ChronoUnit.MONTHS); thisZdt = thisZdt.plusMonths(months)
-    val days = thisZdt.until(otherZdt, ChronoUnit.DAYS); thisZdt = thisZdt.plusDays(days)
-    val nanoseconds = thisZdt.until(otherZdt, ChronoUnit.NANOS)
-
-    return buildDateTimePeriod(months, days.toInt(), nanoseconds)
-}
+@PublishedApi
+@JvmName("periodUntil")
+internal fun Instant.periodUntilJvm(other: Instant, timeZone: TimeZone): DateTimePeriod =
+    toStdlibInstant().periodUntil(other.toStdlibInstant(), timeZone)
 
 @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-    level = DeprecationLevel.WARNING,
+    level = DeprecationLevel.HIDDEN,
     replaceWith = ReplaceWith("this.toStdlibInstant().until(other.toStdlibInstant(), unit, timeZone)")
 )
-public actual fun Instant.until(other: Instant, unit: DateTimeUnit, timeZone: TimeZone): Long = try {
-    val thisZdt = this.atZone(timeZone)
-    val otherZdt = other.atZone(timeZone)
-    when(unit) {
-        is DateTimeUnit.TimeBased -> until(other, unit)
-        is DateTimeUnit.DayBased -> thisZdt.until(otherZdt, ChronoUnit.DAYS) / unit.days
-        is DateTimeUnit.MonthBased -> thisZdt.until(otherZdt, ChronoUnit.MONTHS) / unit.months
-    }
-} catch (e: DateTimeException) {
-    throw DateTimeArithmeticException(e)
-} catch (e: ArithmeticException) {
-    if (this.value < other.value) Long.MAX_VALUE else Long.MIN_VALUE
-}
+@PublishedApi
+@JvmName("until")
+internal fun Instant.untilJvm(other: Instant, unit: DateTimeUnit, timeZone: TimeZone): Long =
+    toStdlibInstant().until(other.toStdlibInstant(), unit, timeZone)


### PR DESCRIPTION
This PR is simply a refactoring and shouldn't change any behaviors.

* Simplified the implementation to have only a single implementation of Instant arithmetic-- the kotlin.time.Instant one.
* Removed some `expect`/`actual` pairs to more easily ensure uniformity between targets.

The goal of this PR is to help with generalizing the JVM Instant arithmetic implementation to handle non-java.time.ZoneId time zones, which is going to be necessary for timezone database injection.