### PR TITLE
Always output seconds in DateTimeComponents.Formats.RFC_1123

### DIFF
--- a/core/common/src/format/DateTimeComponents.kt
+++ b/core/common/src/format/DateTimeComponents.kt
@@ -157,7 +157,7 @@ public class DateTimeComponents internal constructor(internal val contents: Date
             hour()
             char(':')
             minute()
-            optional {
+            alternativeParsing({}) {
                 char(':')
                 second()
             }

--- a/core/common/test/format/DateTimeComponentsFormatTest.kt
+++ b/core/common/test/format/DateTimeComponentsFormatTest.kt
@@ -73,7 +73,7 @@ class DateTimeComponentsFormatTest {
             put(dateTimeComponents(LocalDate(2008, 6, 30), LocalTime(11, 5, 30), UtcOffset.ZERO), ("Mon, 30 Jun 2008 11:05:30 GMT" to setOf()))
             put(dateTimeComponents(LocalDate(2008, 6, 3), LocalTime(11, 5, 30), UtcOffset(hours = 2)), ("Tue, 3 Jun 2008 11:05:30 +0200" to setOf()))
             put(dateTimeComponents(LocalDate(2008, 6, 30), LocalTime(11, 5, 30), UtcOffset(hours = -3)), ("Mon, 30 Jun 2008 11:05:30 -0300" to setOf()))
-            put(dateTimeComponents(LocalDate(2008, 6, 30), LocalTime(11, 5, 0), UtcOffset(hours = -3)), ("Mon, 30 Jun 2008 11:05 -0300" to setOf("Mon, 30 Jun 2008 11:05:00 -0300")))
+            put(dateTimeComponents(LocalDate(2008, 6, 30), LocalTime(11, 5, 0), UtcOffset(hours = -3)), ("Mon, 30 Jun 2008 11:05:00 -0300" to setOf("Mon, 30 Jun 2008 11:05 -0300")))
         }
         test(bags, DateTimeComponents.Formats.RFC_1123)
     }


### PR DESCRIPTION
See #351: we have decided earlier that our format-specific parsers must be predictable first and foremost.
That decision was implemented for ISO 8601 formats, but is just as applicable to RFC 1123 dates.
This change implements consistent formatting for RFC 1123.

Fixes #608