### PR TITLE
Update Kover to 0.9.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 plugins {
     id("kotlinx.team.infra") version "0.4.0-dev-85"
     kotlin("multiplatform") apply false
-    id("org.jetbrains.kotlinx.kover") version "0.8.0-Beta2"
+    id("org.jetbrains.kotlinx.kover") version "0.9.8"
 }
 
 infra {


### PR DESCRIPTION
Update Kover to the recent version.

The main motivation: KUP fails with Kotlin 2.4 due to removal of some APIs used in the Kover 0.8.