### PR TITLE
Version 0.8.0-rc01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # CHANGELOG
 
+## 0.8.0-rc01
+
+Breaking changes:
+
+- Deprecate `TimeZone` serialization ([#576](https://github.com/Kotlin/kotlinx-datetime/issues/576)).
+
+Additions:
+
+- Add `orNull` functions for non-throwing construction of datetime entities ([#68](https://github.com/Kotlin/kotlinx-datetime/issues/68)).
+- Add `parseOrNull` extension functions for non-throwing attempts at parsing ([#508](https://github.com/Kotlin/kotlinx-datetime/pull/508)).
+- Introduce `LocalIsoWeekDate` for representing [ISO week dates](https://en.wikipedia.org/wiki/ISO_week_date) ([#603](https://github.com/Kotlin/kotlinx-datetime/pull/603)).
+- Introduce functions for finding the next or previous date with the given day-of-week ([#129](https://github.com/Kotlin/kotlinx-datetime/issues/129)).
+
+Tweaks and fixes:
+
+- Fix bugs in `Instant.until` and `Instant.periodUntil` ([#534](https://github.com/Kotlin/kotlinx-datetime/pull/534)).
+- Always output seconds in the `DateTimeComponents.Formats.RFC_1123` format ([#608](https://github.com/Kotlin/kotlinx-datetime/pull/608)).
+- On Kotlin/Native for Windows, whenever DST transitions are turned off by the user, the current system time zone is now fixed-offset ([#575](https://github.com/Kotlin/kotlinx-datetime/issues/575)).
+
 ## 0.7.1
 
 - Add `kotlinx.datetime.Instant` and `kotlinx.datetime.Clock` type aliases to, respectively, `kotlin.time.Instant` and `kotlin.time.Clock` to make migration more convenient.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Kotlin Alpha](https://kotl.in/badges/alpha.svg)](https://kotlinlang.org/docs/components-stability.html)
 [![JetBrains official project](https://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
-[![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx/kotlinx-datetime?filter=0.7.1)](https://search.maven.org/search?q=g:org.jetbrains.kotlinx%20AND%20a:kotlinx-datetime)
+[![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx/kotlinx-datetime?filter=0.8.0-rc01)](https://search.maven.org/search?q=g:org.jetbrains.kotlinx%20AND%20a:kotlinx-datetime)
 [![Kotlin](https://img.shields.io/badge/kotlin-2.1.20-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![KDoc link](https://img.shields.io/badge/API_reference-KDoc-blue)](https://kotlinlang.org/api/kotlinx-datetime/)
 [![Slack channel](https://img.shields.io/badge/chat-slack-blue.svg?logo=slack)](https://kotlinlang.slack.com/messages/kotlinx-datetime/)
@@ -466,7 +466,7 @@ kotlin {
     sourceSets {
         commonMain {
              dependencies {
-                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.7.1")
+                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0-rc01")
              }
         }
     }
@@ -477,7 +477,7 @@ kotlin {
 
 ```groovy
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.7.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0-rc01")
 }
 ```
 
@@ -553,7 +553,7 @@ kotlin {
     sourceSets {
         val wasmWasiMain by getting {
             dependencies {
-                implementation("kotlinx-datetime-zoneinfo", "2026a-spi.0.7.1")
+                implementation("kotlinx-datetime-zoneinfo", "2026a-spi.0.8.0-rc01")
             }
         }
     }
@@ -568,7 +568,7 @@ Add a dependency to the `<dependencies>` element. Note that you need to use the 
 <dependency>
     <groupId>org.jetbrains.kotlinx</groupId>
     <artifactId>kotlinx-datetime-jvm</artifactId>
-    <version>0.7.1</version>
+    <version>0.8.0-rc01</version>
 </dependency>
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2G -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.java.installations.fromEnv=JDK_8
 
 group=org.jetbrains.kotlinx
-version=0.7.1
+version=0.8.0-rc01
 versionSuffix=SNAPSHOT
 
 tzdbVersion=2026a


### PR DESCRIPTION
Notes:
- This release is behind schedule on `kotlinx.datetime.Instant` removal: https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/instant.md#description-of-the-process According to the plan, 0.8.0 is supposed to advance the deprecation level on `kotlinx.datetime.Instant` in the compatibility artifact to `ERROR`. However, despite the major version bump (necessary due to a breaking change being included), 0.8.0 is actually quite a minor release, mostly consisting of small convenience API additions. It makes sense to try reducing the friction of upgrading to it. `0.9.x` will include more significant breaking changes and require upgrading to a new Kotlin version, one where `kotlin.time.Instant` is stable—promoting the deprecation to `ERROR` there feels to me like a good fit.
- The version scheme is new. Previously, we had `RC1` or `RC.1`, but as part of a Kotlin-wide effort for unified versioning, this is `rc01` now, even though it's inconsistent with our earlier choices. `kotlinx.coroutines` already published such a release: https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.11.0-rc01