### PR TITLE
Update KDoc reference for `YearMonth.parseOrNull` to reference `Companion`

### DIFF
--- a/core/common/src/YearMonth.kt
+++ b/core/common/src/YearMonth.kt
@@ -187,7 +187,7 @@ public constructor(year: Int, month: Int) : Comparable<YearMonth> {
          *
          * @see YearMonth.toString for formatting using the default format.
          * @see YearMonth.format for formatting using a custom format.
-         * @see YearMonth.parseOrNull for a version of this function that returns `null` on faulty input.
+         * @see YearMonth.Companion.parseOrNull for a version of this function that returns `null` on faulty input.
          * @sample kotlinx.datetime.test.samples.YearMonthSamples.parsing
          */
         public fun parse(input: CharSequence, format: DateTimeFormat<YearMonth> = Formats.ISO): YearMonth


### PR DESCRIPTION
This is a know issue in Dokka (https://github.com/Kotlin/dokka/issues/3748), that will be fixed in https://github.com/Kotlin/dokka/issues/4438.