### PR TITLE
Allow newer version of `@js-joda/core` than 3.2.0

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -199,7 +199,7 @@ kotlin {
         val commonJsMain by getting {
             dependencies {
                 api("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
-                implementation(npm("@js-joda/core", ">= 3.2.0"))
+                implementation(npm("@js-joda/core", ">= 3.2.0 < 7.0.0"))
             }
         }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -199,7 +199,7 @@ kotlin {
         val commonJsMain by getting {
             dependencies {
                 api("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
-                implementation(npm("@js-joda/core", "3.2.0"))
+                implementation(npm("@js-joda/core", ">= 3.2.0"))
             }
         }
 

--- a/integration-testing/js-with-timezones/build.gradle.kts
+++ b/integration-testing/js-with-timezones/build.gradle.kts
@@ -27,12 +27,12 @@ kotlin {
         }
         jsMain {
             dependencies {
-                implementation(npm("@js-joda/timezone", "2.3.0"))
+                implementation(npm("@js-joda/timezone", "2.25.1"))
             }
         }
         wasmJsMain {
             dependencies {
-                implementation(npm("@js-joda/timezone", "2.3.0"))
+                implementation(npm("@js-joda/timezone", "2.25.1"))
             }
         }
     }

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -14,7 +14,7 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
-"@js-joda/core@>= 3.2.0":
+"@js-joda/core@>= 3.2.0 < 7.0.0":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-6.0.1.tgz#372b56137a0345333b12c6801ee48edd7435ef34"
   integrity sha512-Iev3Cfa3MC+06JXXeFzSLew/7yeCXLMhjesyH/BD4EQYlUUDV49Ln3s8hd7p5XK5UesO/dO3K1LFJ7RT7v0Ddg==

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -14,10 +14,15 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
-"@js-joda/core@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
-  integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
+"@js-joda/core@>= 3.2.0":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-6.0.1.tgz#372b56137a0345333b12c6801ee48edd7435ef34"
+  integrity sha512-Iev3Cfa3MC+06JXXeFzSLew/7yeCXLMhjesyH/BD4EQYlUUDV49Ln3s8hd7p5XK5UesO/dO3K1LFJ7RT7v0Ddg==
+
+"@js-joda/timezone@2.25.1":
+  version "2.25.1"
+  resolved "https://registry.yarnpkg.com/@js-joda/timezone/-/timezone-2.25.1.tgz#4628f18d51af1b197a410834d344418f48a8a264"
+  integrity sha512-s79ts8bXrWqM9dIBKc0AdgGuAUFpu9gmzYhOCPHJlks/Sf7FSbJHRauWlFYUwjSTZevimqthEvJycrwrVz5m4g==
 
 "@js-joda/timezone@2.3.0":
   version "2.3.0"


### PR DESCRIPTION
Fixes #627