### PR TITLE
Reflect in README that compatibility versions will be published for 0.8.x versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ Tips for fixing compilation errors:
     * `kotlinx.datetime.Instant.toStdlibInstant(): kotlin.time.Instant`
     * `kotlinx.datetime.Clock.toStdlibClock(): kotlin.time.Clock`
 
-> Compatibility releases will be published for all `0.7.x` versions of `kotlinx-datetime`, but not longer.
+> Compatibility releases will be published for versions up to `0.8.x` of `kotlinx-datetime`, but not longer.
 
 ### Gradle
 


### PR DESCRIPTION
Reflect in README that compatibility versions related to the deprecation of `Instant` will be published for `0.8.x` versions of the library as well, as version `0.8.0-0.6.x-compat` is already available.