### PR TITLE
Simplify the `TimeZone` operation implementations on the JVM

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 sourceSets {
     dependencies {
         implementation(project(":kotlinx-datetime"))
+        implementation(project(":kotlinx-datetime-zoneinfo"))
         implementation("org.openjdk.jmh:jmh-core:1.35")
     }
 }

--- a/benchmarks/src/jmh/kotlin/TimeZoneOperations.kt
+++ b/benchmarks/src/jmh/kotlin/TimeZoneOperations.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019-2026 JetBrains s.r.o. and contributors.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.datetime
+
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.TimeUnit
+import kotlin.time.Clock
+
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+open class TimeZoneOperations {
+    val timeZone = TimeZoneContext.System.get("Europe/Berlin")
+    val dateIn1970 = LocalDate(1970, 1, 1)
+    val dateTimeIn1970 = dateIn1970.atTime(12, 30)
+    val instantIn1970 = kotlin.time.Instant.fromEpochMilliseconds(0)
+    val dateToday = Clock.System.todayIn(timeZone)
+    val dateTimeToday = dateToday.atTime(12, 30)
+    val instantToday = Clock.System.now()
+
+    @Benchmark
+    fun atStartOfDayRecurringRules() = dateToday.atStartOfDayIn(timeZone)
+
+    @Benchmark
+    fun atStartOfDayHistoricRules() = dateIn1970.atStartOfDayIn(timeZone)
+
+    @Benchmark
+    fun localDateTimeToInstantRecurringRules() = dateTimeToday.toInstant(timeZone, TransitionHandler.USE_OFFSET_BEFORE)
+
+    @Benchmark
+    fun localDateTimeToInstantHistoricRules() = dateTimeIn1970.toInstant(timeZone, TransitionHandler.USE_OFFSET_BEFORE)
+
+    @Benchmark
+    fun instantToLocalDateTimeRecurringRules() = instantToday.toLocalDateTime(timeZone)
+
+    @Benchmark
+    fun instantToLocalDateTimeHistoricRules() = instantIn1970.toLocalDateTime(timeZone)
+
+    @Benchmark
+    fun offsetInRecurringRules() = instantToday.offsetIn(timeZone)
+
+    @Benchmark
+    fun offsetInHistoricRules() = instantIn1970.offsetIn(timeZone)
+
+    @Benchmark
+    fun offsetInfoForRecurringRules() = timeZone.offsetInfoFor(dateTimeToday)
+
+    @Benchmark
+    fun offsetInfoForHistoricRules() = timeZone.offsetInfoFor(dateTimeIn1970)
+}

--- a/benchmarks/src/jmh/kotlin/UtcOffsetOperations.kt
+++ b/benchmarks/src/jmh/kotlin/UtcOffsetOperations.kt
@@ -23,4 +23,8 @@ open class UtcOffsetOperations {
 
     @Benchmark
     fun localDateTimeToInstant() = dateTimeToday.toInstant(offset)
+
+    @Suppress("INVISIBLE_REFERENCE")
+    @Benchmark
+    fun instantToLocalDateTime() = instantToday.toLocalDateTime(offset)
 }

--- a/benchmarks/src/jmh/kotlin/UtcOffsetOperations.kt
+++ b/benchmarks/src/jmh/kotlin/UtcOffsetOperations.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019-2026 JetBrains s.r.o. and contributors.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.datetime
+
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.TimeUnit
+import kotlin.time.Clock
+
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+open class UtcOffsetOperations {
+    val dateToday = Clock.System.todayIn(TimeZone.UTC)
+    val dateTimeToday = dateToday.atTime(12, 30)
+    val instantToday = Clock.System.now()
+    val offset = UtcOffset(hours = 2)
+
+    @Benchmark
+    fun localDateTimeToInstant() = dateTimeToday.toInstant(offset)
+}

--- a/core/common/src/TimeZone.kt
+++ b/core/common/src/TimeZone.kt
@@ -320,7 +320,11 @@ public fun TimeZone.offsetAt(instant: kotlinx.datetime.Instant): UtcOffset =
  * @throws DateTimeArithmeticException if this value is too large to fit in [LocalDateTime].
  * @sample kotlinx.datetime.test.samples.TimeZoneSamples.instantToLocalDateTime
  */
-public expect fun Instant.toLocalDateTime(timeZone: TimeZone): LocalDateTime
+public fun Instant.toLocalDateTime(timeZone: TimeZone): LocalDateTime = try {
+    toLocalDateTime(offsetIn(timeZone))
+} catch (e: IllegalArgumentException) {
+    throw DateTimeArithmeticException("Instant $this is not representable as LocalDateTime.", e)
+}
 
 @Suppress("DEPRECATION")
 @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",

--- a/core/common/src/TimeZone.kt
+++ b/core/common/src/TimeZone.kt
@@ -436,28 +436,24 @@ public expect fun LocalDateTime.toInstant(timeZone: TimeZone, youShallNotPass: O
  */
 public fun LocalDateTime.toInstant(
     timeZone: TimeZone, onTransition: TransitionHandler, utcOffset: UtcOffset? = null
-): Instant = if (onTransition === TransitionHandler.USE_OFFSET_BEFORE && utcOffset === null) {
-    optimizedToInstantOffsetBefore(timeZone)
-} else {
-    when (val offsetInfo = timeZone.offsetInfoFor(this)) {
-        is LocalDateTimeOffsetInfo.Regular -> {
-            require(utcOffset == null || utcOffset == offsetInfo.offset) {
-                "The supplied UTC offset $utcOffset did not match the actual UTC offset ${offsetInfo.offset} " +
-                    "at $this in the time zone $timeZone"
-            }
-            toInstant(offsetInfo.offset)
+): Instant = when (val offsetInfo = timeZone.offsetInfoFor(this)) {
+    is LocalDateTimeOffsetInfo.Regular -> {
+        require(utcOffset == null || utcOffset == offsetInfo.offset) {
+            "The supplied UTC offset $utcOffset did not match the actual UTC offset ${offsetInfo.offset} " +
+                "at $this in the time zone $timeZone"
         }
-        is LocalDateTimeOffsetInfo.Transition -> {
-            require(utcOffset == null || utcOffset == offsetInfo.offsetBefore || utcOffset == offsetInfo.offsetAfter) {
-                "The supplied UTC offset $utcOffset did not match any of the offset " +
-                    "surrounding the transition $offsetInfo at $this in the time zone $timeZone"
-            }
-            onTransition.resolveDateTime(
-                dateTime = this,
-                transition = offsetInfo,
-                preferredOffset = utcOffset,
-            )
+        toInstant(offsetInfo.offset)
+    }
+    is LocalDateTimeOffsetInfo.Transition -> {
+        require(utcOffset == null || utcOffset == offsetInfo.offsetBefore || utcOffset == offsetInfo.offsetAfter) {
+            "The supplied UTC offset $utcOffset did not match any of the offset " +
+                "surrounding the transition $offsetInfo at $this in the time zone $timeZone"
         }
+        onTransition.resolveDateTime(
+            dateTime = this,
+            transition = offsetInfo,
+            preferredOffset = utcOffset,
+        )
     }
 }
 
@@ -541,5 +537,3 @@ internal fun localDateTimeToInstantLenient(
         handler.resolveDateTime(dateTime, offsetInfo, actualPreferred)
     }
 }
-
-internal expect fun LocalDateTime.optimizedToInstantOffsetBefore(timeZone: TimeZone): Instant

--- a/core/common/src/TimeZone.kt
+++ b/core/common/src/TimeZone.kt
@@ -503,7 +503,12 @@ internal fun LocalDateTime.toInstant(offset: UtcOffset): kotlinx.datetime.Instan
  * @sample kotlinx.datetime.test.samples.TimeZoneSamples.atStartOfDayIn
  */
 @Suppress("DEPRECATION_ERROR")
-public expect fun LocalDate.atStartOfDayIn(timeZone: TimeZone, youShallNotPass: OverloadMarker = OverloadMarker.INSTANCE): Instant
+public fun LocalDate.atStartOfDayIn(timeZone: TimeZone, youShallNotPass: OverloadMarker = OverloadMarker.INSTANCE): Instant {
+    val ldt = atTime(LocalTime.MIN)
+    return localDateTimeToInstantLenient(
+        ldt, timeZone.offsetInfoFor(ldt), TransitionHandler.FIND_EARLIEST_VALID_TIME, preferred = null
+    )
+}
 
 @PublishedApi
 @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "DEPRECATION")

--- a/core/commonKotlin/src/TimeZone.kt
+++ b/core/commonKotlin/src/TimeZone.kt
@@ -78,10 +78,6 @@ public actual open class TimeZone internal constructor() {
     internal actual fun LocalDateTime.toInstant(): kotlinx.datetime.Instant =
         toInstant(this@TimeZone).toDeprecatedInstant()
 
-    internal open fun atStartOfDay(date: LocalDate): Instant = localDateTimeToInstantLenient(
-        LocalDateTime(date, LocalTime.MIN), this, TransitionHandler.FIND_EARLIEST_VALID_TIME, preferred = null
-    )
-
     internal open fun instantToLocalDateTime(instant: Instant): LocalDateTime = try {
         instant.toLocalDateTimeImpl(offsetAt(instant))
     } catch (e: IllegalArgumentException) {
@@ -110,9 +106,6 @@ public actual class FixedOffsetTimeZone internal constructor(public actual val o
 
     @Deprecated("Use offset.totalSeconds", ReplaceWith("offset.totalSeconds"))
     public actual val totalSeconds: Int get() = offset.totalSeconds
-
-    override fun atStartOfDay(date: LocalDate): Instant =
-        LocalDateTime(date, LocalTime.MIN).toInstant(offset)
 
     override fun offsetAt(instant: Instant): UtcOffset = offset
 
@@ -173,10 +166,6 @@ public actual fun LocalDateTime.toInstant(timeZone: TimeZone, youShallNotPass: O
 @Suppress("DEPRECATION_ERROR")
 public actual fun LocalDateTime.toInstant(offset: UtcOffset, youShallNotPass: OverloadMarker): Instant =
     Instant.fromEpochSeconds(this.toEpochSecond(offset), this.nanosecond)
-
-@Suppress("DEPRECATION_ERROR")
-public actual fun LocalDate.atStartOfDayIn(timeZone: TimeZone, youShallNotPass: OverloadMarker): Instant =
-    timeZone.atStartOfDay(this)
 
 internal actual fun LocalDateTime.optimizedToInstantOffsetBefore(timeZone: TimeZone): Instant =
     timeZone.localDateTimeToInstant(this)

--- a/core/commonKotlin/src/TimeZone.kt
+++ b/core/commonKotlin/src/TimeZone.kt
@@ -51,7 +51,7 @@ public actual open class TimeZone internal constructor() {
     public actual open val id: String
         get() = error("Should be overridden")
 
-    public actual fun Instant.toLocalDateTime(): LocalDateTime = instantToLocalDateTime(this)
+    public actual fun Instant.toLocalDateTime(): LocalDateTime = toLocalDateTime(this@TimeZone)
 
     @Suppress("DEPRECATION_ERROR")
     @Deprecated(
@@ -77,12 +77,6 @@ public actual open class TimeZone internal constructor() {
     @kotlin.internal.LowPriorityInOverloadResolution
     internal actual fun LocalDateTime.toInstant(): kotlinx.datetime.Instant =
         toInstant(this@TimeZone).toDeprecatedInstant()
-
-    internal open fun instantToLocalDateTime(instant: Instant): LocalDateTime = try {
-        instant.toLocalDateTimeImpl(offsetAt(instant))
-    } catch (e: IllegalArgumentException) {
-        throw DateTimeArithmeticException("Instant $instant is not representable as LocalDateTime.", e)
-    }
 
     public actual open fun offsetAt(instant: Instant): UtcOffset = error("Should be overridden")
 
@@ -115,8 +109,6 @@ public actual class FixedOffsetTimeZone internal constructor(public actual val o
     override fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset?): Instant =
         dateTime.toInstant(offset)
 
-    override fun instantToLocalDateTime(instant: Instant): LocalDateTime = instant.toLocalDateTime(offset)
-
     override fun equals(other: Any?): Boolean =
         this === other || other is FixedOffsetTimeZone && this.id == other.id
 
@@ -140,9 +132,6 @@ public actual class FixedOffsetTimeZone internal constructor(public actual val o
 @PublishedApi
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 internal fun TimeZone.offsetAt(instant: Instant): UtcOffset = offsetAt(instant) // member shadows the extension
-
-public actual fun Instant.toLocalDateTime(timeZone: TimeZone): LocalDateTime =
-    timeZone.instantToLocalDateTime(this)
 
 internal actual fun Instant.toLocalDateTime(offset: UtcOffset): LocalDateTime = try {
     toLocalDateTimeImpl(offset)

--- a/core/commonKotlin/src/TimeZone.kt
+++ b/core/commonKotlin/src/TimeZone.kt
@@ -156,6 +156,3 @@ public actual fun LocalDateTime.toInstant(timeZone: TimeZone, youShallNotPass: O
 public actual fun LocalDateTime.toInstant(offset: UtcOffset, youShallNotPass: OverloadMarker): Instant =
     Instant.fromEpochSeconds(this.toEpochSecond(offset), this.nanosecond)
 
-internal actual fun LocalDateTime.optimizedToInstantOffsetBefore(timeZone: TimeZone): Instant =
-    timeZone.localDateTimeToInstant(this)
-

--- a/core/darwin/test/TimeZoneNativeTest.kt
+++ b/core/darwin/test/TimeZoneNativeTest.kt
@@ -372,7 +372,7 @@ class TimeZoneNativeTest {
         assertEquals(expectedType, actualType)
     }
 
-    // timeZone.atStartOfDay(LocalDate) tests
+    // LocalDate.atStartOfDayIn(TimeZone) tests
 
     @Test
     fun shouldProduceConsistentInstanceBetweenRegularAndFoundationTimeZones() {
@@ -382,8 +382,8 @@ class TimeZoneNativeTest {
 
             for ((localDateTime, _) in localDateTimes) {
                 val date = localDateTime.date
-                val regularInstance = regularTz.atStartOfDay(date)
-                val foundationInstance = foundationTz.atStartOfDay(date)
+                val regularInstance = date.atStartOfDayIn(regularTz)
+                val foundationInstance = date.atStartOfDayIn(foundationTz)
 
                 assertEquals(regularInstance, foundationInstance)
             }

--- a/core/jvm/src/TimeZoneJvm.kt
+++ b/core/jvm/src/TimeZoneJvm.kt
@@ -146,7 +146,7 @@ internal fun TimeZone.offsetAt(instant: Instant): UtcOffset =
     zoneId.offsetAt(instant)
 
 public actual fun Instant.toLocalDateTime(timeZone: TimeZone): LocalDateTime =
-    timeZone.zoneId.instantToLocalDateTime(this)
+    toLocalDateTime(timeZone.zoneId.offsetAt(this))
 
 internal actual fun Instant.toLocalDateTime(offset: UtcOffset): LocalDateTime = try {
     LocalDateTime(java.time.LocalDateTime.ofEpochSecond(epochSeconds, nanosecondsOfSecond, offset.zoneOffset))
@@ -176,8 +176,6 @@ internal sealed interface ZoneIdLike {
 
     fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo
 
-    fun instantToLocalDateTime(instant: Instant): LocalDateTime
-
     fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset?): Instant
 
     class ActualZoneId(val actualZoneId: ZoneId) : ZoneIdLike {
@@ -199,12 +197,6 @@ internal sealed interface ZoneIdLike {
                     transition.offsetAfter.let(::UtcOffset),
                 )
             }
-        }
-
-        override fun instantToLocalDateTime(instant: Instant): LocalDateTime = try {
-            java.time.LocalDateTime.ofInstant(instant.toJavaInstant(), actualZoneId).let(::LocalDateTime)
-        } catch (e: DateTimeException) {
-            throw DateTimeArithmeticException(e)
         }
 
         override fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset?): Instant =
@@ -233,9 +225,6 @@ internal sealed interface ZoneIdLike {
                 TransitionHandler.USE_OFFSET_BEFORE,
                 preferred
             )
-
-        override fun instantToLocalDateTime(instant: Instant): LocalDateTime =
-            instant.toLocalDateTime(offsetAt(instant))
 
         override fun equals(other: Any?): Boolean = other is RuleBasedZoneId && zoneRules == other.zoneRules
         override fun hashCode(): Int = zoneRules.hashCode()

--- a/core/jvm/src/TimeZoneJvm.kt
+++ b/core/jvm/src/TimeZoneJvm.kt
@@ -145,9 +145,6 @@ internal constructor(public actual val offset: UtcOffset, zoneId: ZoneId): TimeZ
 internal fun TimeZone.offsetAt(instant: Instant): UtcOffset =
     zoneId.offsetAt(instant)
 
-public actual fun Instant.toLocalDateTime(timeZone: TimeZone): LocalDateTime =
-    toLocalDateTime(timeZone.zoneId.offsetAt(this))
-
 internal actual fun Instant.toLocalDateTime(offset: UtcOffset): LocalDateTime = try {
     LocalDateTime(java.time.LocalDateTime.ofEpochSecond(epochSeconds, nanosecondsOfSecond, offset.zoneOffset))
 } catch (e: DateTimeException) {

--- a/core/jvm/src/TimeZoneJvm.kt
+++ b/core/jvm/src/TimeZoneJvm.kt
@@ -167,7 +167,7 @@ internal actual fun LocalDateTime.optimizedToInstantOffsetBefore(timeZone: TimeZ
 
 @Suppress("DEPRECATION_ERROR")
 public actual fun LocalDateTime.toInstant(offset: UtcOffset, youShallNotPass: OverloadMarker): Instant =
-    this.value.toInstant(offset.zoneOffset).toKotlinInstant()
+    Instant.fromEpochSeconds(this.value.toEpochSecond(offset.zoneOffset), this.nanosecond)
 
 internal sealed interface ZoneIdLike {
     val id: String

--- a/core/jvm/src/TimeZoneJvm.kt
+++ b/core/jvm/src/TimeZoneJvm.kt
@@ -8,11 +8,12 @@
 
 package kotlinx.datetime
 
+import kotlinx.datetime.TransitionHandler
 import kotlinx.datetime.internal.RuleBasedTimeZoneCalculations
 import kotlinx.datetime.serializers.*
+import kotlinx.datetime.toInstant
 import java.time.DateTimeException
 import java.time.ZoneId
-import java.time.ZonedDateTime
 import java.time.ZoneOffset as jtZoneOffset
 import kotlin.time.Instant
 import kotlin.time.toJavaInstant
@@ -36,7 +37,7 @@ public actual open class TimeZone internal constructor(internal val zoneId: Zone
         replaceWith = ReplaceWith("this.toInstant(TransitionHandler.USE_OFFSET_BEFORE)")
     )
     public actual fun LocalDateTime.toInstant(youShallNotPass: OverloadMarker): Instant =
-        optimizedToInstantOffsetBefore(this@TimeZone)
+        toInstant(this@TimeZone, TransitionHandler.USE_OFFSET_BEFORE)
 
     public actual fun LocalDateTime.toInstant(onTransition: TransitionHandler, utcOffset: UtcOffset?): Instant =
         this@toInstant.toInstant(this@TimeZone, onTransition, utcOffset)
@@ -157,10 +158,7 @@ internal actual fun Instant.toLocalDateTime(offset: UtcOffset): LocalDateTime = 
     replaceWith = ReplaceWith("this.toInstant(timeZone, TransitionHandler.USE_OFFSET_BEFORE)")
 )
 public actual fun LocalDateTime.toInstant(timeZone: TimeZone, youShallNotPass: OverloadMarker): Instant =
-    optimizedToInstantOffsetBefore(timeZone)
-
-internal actual fun LocalDateTime.optimizedToInstantOffsetBefore(timeZone: TimeZone): Instant =
-    timeZone.zoneId.localDateTimeToInstant(this, null)
+    toInstant(timeZone, TransitionHandler.USE_OFFSET_BEFORE)
 
 @Suppress("DEPRECATION_ERROR")
 public actual fun LocalDateTime.toInstant(offset: UtcOffset, youShallNotPass: OverloadMarker): Instant =
@@ -172,8 +170,6 @@ internal sealed interface ZoneIdLike {
     fun offsetAt(instant: Instant): UtcOffset
 
     fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo
-
-    fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset?): Instant
 
     class ActualZoneId(val actualZoneId: ZoneId) : ZoneIdLike {
         override val id: String
@@ -198,11 +194,6 @@ internal sealed interface ZoneIdLike {
             )
         }
 
-        override fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset?): Instant =
-            java.time.ZonedDateTime.ofLocal(
-                dateTime.value, actualZoneId, preferred?.zoneOffset
-            ).toInstant().toKotlinInstant()
-
         override fun equals(other: Any?): Boolean = other is ActualZoneId && actualZoneId == other.actualZoneId
         override fun hashCode(): Int = actualZoneId.hashCode()
         override fun toString(): String = actualZoneId.toString()
@@ -216,14 +207,6 @@ internal sealed interface ZoneIdLike {
 
         override fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
             zoneRules.offsetInfoFor(dateTime)
-
-        override fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset?): Instant =
-            localDateTimeToInstantLenient(
-                dateTime,
-                offsetInfoFor(dateTime),
-                TransitionHandler.USE_OFFSET_BEFORE,
-                preferred
-            )
 
         override fun equals(other: Any?): Boolean = other is RuleBasedZoneId && zoneRules == other.zoneRules
         override fun hashCode(): Int = zoneRules.hashCode()

--- a/core/jvm/src/TimeZoneJvm.kt
+++ b/core/jvm/src/TimeZoneJvm.kt
@@ -184,16 +184,18 @@ internal sealed interface ZoneIdLike {
 
         override fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo {
             val rules = actualZoneId.rules
-            val transition = rules.getTransition(dateTime.value)
-            return if (transition == null) {
-                LocalDateTimeOffsetInfo.Regular(rules.getOffset(dateTime.value).let(::UtcOffset))
-            } else {
-                LocalDateTimeOffsetInfo.Transition(
-                    transition.instant.toKotlinInstant(),
-                    transition.offsetBefore.let(::UtcOffset),
-                    transition.offsetAfter.let(::UtcOffset),
-                )
+            val validOffsets = rules.getValidOffsets(dateTime.value)
+            validOffsets.singleOrNull()?.let { offset ->
+                // fast path for the common case of only a single offset: we're making only one call to the Java API
+                return LocalDateTimeOffsetInfo.Regular(UtcOffset(offset))
             }
+            val transition = rules.getTransition(dateTime.value)
+            check(transition != null) { "Inconsistent reading: no transition at $dateTime, offsets: $validOffsets" }
+            return LocalDateTimeOffsetInfo.Transition(
+                transition.instant.toKotlinInstant(),
+                transition.offsetBefore.let(::UtcOffset),
+                transition.offsetAfter.let(::UtcOffset),
+            )
         }
 
         override fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset?): Instant =

--- a/core/jvm/src/TimeZoneJvm.kt
+++ b/core/jvm/src/TimeZoneJvm.kt
@@ -12,6 +12,7 @@ import kotlinx.datetime.internal.RuleBasedTimeZoneCalculations
 import kotlinx.datetime.serializers.*
 import java.time.DateTimeException
 import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.ZoneOffset as jtZoneOffset
 import kotlin.time.Instant
 import kotlin.time.toJavaInstant
@@ -168,10 +169,6 @@ internal actual fun LocalDateTime.optimizedToInstantOffsetBefore(timeZone: TimeZ
 public actual fun LocalDateTime.toInstant(offset: UtcOffset, youShallNotPass: OverloadMarker): Instant =
     this.value.toInstant(offset.zoneOffset).toKotlinInstant()
 
-@Suppress("DEPRECATION_ERROR")
-public actual fun LocalDate.atStartOfDayIn(timeZone: TimeZone, youShallNotPass: OverloadMarker): Instant =
-    timeZone.zoneId.atStartOfDay(this)
-
 internal sealed interface ZoneIdLike {
     val id: String
 
@@ -180,8 +177,6 @@ internal sealed interface ZoneIdLike {
     fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo
 
     fun instantToLocalDateTime(instant: Instant): LocalDateTime
-
-    fun atStartOfDay(date: LocalDate): Instant
 
     fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset?): Instant
 
@@ -212,9 +207,6 @@ internal sealed interface ZoneIdLike {
             throw DateTimeArithmeticException(e)
         }
 
-        override fun atStartOfDay(date: LocalDate): Instant =
-            date.value.atStartOfDay(actualZoneId).toInstant().toKotlinInstant()
-
         override fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset?): Instant =
             java.time.ZonedDateTime.ofLocal(
                 dateTime.value, actualZoneId, preferred?.zoneOffset
@@ -233,13 +225,6 @@ internal sealed interface ZoneIdLike {
 
         override fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
             zoneRules.offsetInfoFor(dateTime)
-
-        override fun atStartOfDay(date: LocalDate): Instant {
-            val ldt = LocalDateTime(date, LocalTime.MIN)
-            return localDateTimeToInstantLenient(
-                ldt, offsetInfoFor(ldt), TransitionHandler.FIND_EARLIEST_VALID_TIME, preferred = null
-            )
-        }
 
         override fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset?): Instant =
             localDateTimeToInstantLenient(

--- a/core/jvm/src/TimeZoneJvm.kt
+++ b/core/jvm/src/TimeZoneJvm.kt
@@ -149,7 +149,7 @@ public actual fun Instant.toLocalDateTime(timeZone: TimeZone): LocalDateTime =
     timeZone.zoneId.instantToLocalDateTime(this)
 
 internal actual fun Instant.toLocalDateTime(offset: UtcOffset): LocalDateTime = try {
-    java.time.LocalDateTime.ofInstant(this.toJavaInstant(), offset.zoneOffset).let(::LocalDateTime)
+    LocalDateTime(java.time.LocalDateTime.ofEpochSecond(epochSeconds, nanosecondsOfSecond, offset.zoneOffset))
 } catch (e: DateTimeException) {
     throw DateTimeArithmeticException(e)
 }


### PR DESCRIPTION
The performance has for the most part significantly improved.

Before:

```
Benchmark                                                 Mode  Cnt    Score   Error   Units
TimeZoneOperations.atStartOfDayHistoricRules             thrpt    5   39.881 ± 0.913  ops/us
TimeZoneOperations.atStartOfDayRecurringRules            thrpt    5   15.797 ± 0.154  ops/us
TimeZoneOperations.instantToLocalDateTimeHistoricRules   thrpt    5   53.501 ± 0.275  ops/us
TimeZoneOperations.instantToLocalDateTimeRecurringRules  thrpt    5   37.481 ± 0.149  ops/us
TimeZoneOperations.localDateTimeToInstantHistoricRules   thrpt    5   56.333 ± 0.348  ops/us
TimeZoneOperations.localDateTimeToInstantRecurringRules  thrpt    5   25.311 ± 0.061  ops/us
TimeZoneOperations.offsetInfoForHistoricRules            thrpt    5   58.297 ± 0.570  ops/us
TimeZoneOperations.offsetInfoForRecurringRules           thrpt    5   18.905 ± 0.162  ops/us
UtcOffsetOperations.instantToLocalDateTime               thrpt    5   69.993 ± 0.124  ops/us
UtcOffsetOperations.localDateTimeToInstant               thrpt    5  120.026 ± 0.334  ops/us
```

After:

```
Benchmark                                                 Mode  Cnt    Score   Error   Units
TimeZoneOperations.atStartOfDayHistoricRules             thrpt    5   64.898 ± 0.689  ops/us
TimeZoneOperations.atStartOfDayRecurringRules            thrpt    5   29.402 ± 0.251  ops/us
TimeZoneOperations.instantToLocalDateTimeHistoricRules   thrpt    5   54.861 ± 0.890  ops/us
TimeZoneOperations.instantToLocalDateTimeRecurringRules  thrpt    5   36.107 ± 0.391  ops/us
TimeZoneOperations.localDateTimeToInstantHistoricRules   thrpt    5   52.214 ± 2.130  ops/us
TimeZoneOperations.localDateTimeToInstantRecurringRules  thrpt    5   29.294 ± 0.172  ops/us
TimeZoneOperations.offsetInfoForHistoricRules            thrpt    5   85.257 ± 0.542  ops/us
TimeZoneOperations.offsetInfoForRecurringRules           thrpt    5   30.659 ± 0.073  ops/us
UtcOffsetOperations.instantToLocalDateTime               thrpt    5   86.504 ± 0.300  ops/us
UtcOffsetOperations.localDateTimeToInstant               thrpt    5  138.505 ± 0.788  ops/us
```