### PR TITLE
Clarify the TimeZone semantics

### DIFF
--- a/core/api/kotlinx-datetime.api
+++ b/core/api/kotlinx-datetime.api
@@ -732,6 +732,8 @@ public class kotlinx/datetime/TimeZone {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getId ()Ljava/lang/String;
 	public fun hashCode ()I
+	public final fun offsetAt (Lkotlin/time/Instant;)Lkotlinx/datetime/UtcOffset;
+	public final fun offsetInfoFor (Lkotlinx/datetime/LocalDateTime;)Lkotlinx/datetime/LocalDateTimeOffsetInfo;
 	public final fun toInstant (Lkotlinx/datetime/LocalDateTime;)Lkotlinx/datetime/Instant;
 	public final fun toInstant (Lkotlinx/datetime/LocalDateTime;Lkotlinx/datetime/OverloadMarker;)Lkotlin/time/Instant;
 	public final fun toInstant (Lkotlinx/datetime/LocalDateTime;Lkotlinx/datetime/TransitionHandler;Lkotlinx/datetime/UtcOffset;)Lkotlin/time/Instant;
@@ -786,7 +788,6 @@ public final class kotlinx/datetime/TimeZoneKt {
 	public static final fun offsetAt (Lkotlinx/datetime/TimeZone;Lkotlinx/datetime/Instant;)Lkotlinx/datetime/UtcOffset;
 	public static final fun offsetIn (Lkotlin/time/Instant;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/UtcOffset;
 	public static final fun offsetIn (Lkotlinx/datetime/Instant;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/UtcOffset;
-	public static final fun offsetInfoFor (Lkotlinx/datetime/TimeZone;Lkotlinx/datetime/LocalDateTime;)Lkotlinx/datetime/LocalDateTimeOffsetInfo;
 	public static final fun toInstant (Lkotlinx/datetime/LocalDateTime;Lkotlinx/datetime/FixedOffsetTimeZone;)Lkotlin/time/Instant;
 	public static final fun toInstant (Lkotlinx/datetime/LocalDateTime;Lkotlinx/datetime/TimeZone;)Lkotlinx/datetime/Instant;
 	public static final fun toInstant (Lkotlinx/datetime/LocalDateTime;Lkotlinx/datetime/TimeZone;Lkotlinx/datetime/OverloadMarker;)Lkotlin/time/Instant;

--- a/core/api/kotlinx-datetime.klib.api
+++ b/core/api/kotlinx-datetime.klib.api
@@ -458,6 +458,8 @@ final class kotlinx.datetime/FixedOffsetTimeZone : kotlinx.datetime/TimeZone { /
 
     final fun equals(kotlin/Any?): kotlin/Boolean // kotlinx.datetime/FixedOffsetTimeZone.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // kotlinx.datetime/FixedOffsetTimeZone.hashCode|hashCode(){}[0]
+    final fun offsetAt(kotlin.time/Instant): kotlinx.datetime/UtcOffset // kotlinx.datetime/FixedOffsetTimeZone.offsetAt|offsetAt(kotlin.time.Instant){}[0]
+    final fun offsetInfoFor(kotlinx.datetime/LocalDateTime): kotlinx.datetime/LocalDateTimeOffsetInfo // kotlinx.datetime/FixedOffsetTimeZone.offsetInfoFor|offsetInfoFor(kotlinx.datetime.LocalDateTime){}[0]
 
     final object Companion { // kotlinx.datetime/FixedOffsetTimeZone.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<kotlinx.datetime/FixedOffsetTimeZone> // kotlinx.datetime/FixedOffsetTimeZone.Companion.serializer|serializer(){}[0]
@@ -801,6 +803,8 @@ open class kotlinx.datetime/TimeZone { // kotlinx.datetime/TimeZone|null[0]
     final fun (kotlinx.datetime/LocalDateTime).toInstant(kotlinx.datetime/TransitionHandler, kotlinx.datetime/UtcOffset? = ...): kotlin.time/Instant // kotlinx.datetime/TimeZone.toInstant|toInstant@kotlinx.datetime.LocalDateTime(kotlinx.datetime.TransitionHandler;kotlinx.datetime.UtcOffset?){}[0]
     open fun equals(kotlin/Any?): kotlin/Boolean // kotlinx.datetime/TimeZone.equals|equals(kotlin.Any?){}[0]
     open fun hashCode(): kotlin/Int // kotlinx.datetime/TimeZone.hashCode|hashCode(){}[0]
+    open fun offsetAt(kotlin.time/Instant): kotlinx.datetime/UtcOffset // kotlinx.datetime/TimeZone.offsetAt|offsetAt(kotlin.time.Instant){}[0]
+    open fun offsetInfoFor(kotlinx.datetime/LocalDateTime): kotlinx.datetime/LocalDateTimeOffsetInfo // kotlinx.datetime/TimeZone.offsetInfoFor|offsetInfoFor(kotlinx.datetime.LocalDateTime){}[0]
     open fun toString(): kotlin/String // kotlinx.datetime/TimeZone.toString|toString(){}[0]
 
     final object Companion { // kotlinx.datetime/TimeZone.Companion|null[0]
@@ -1369,7 +1373,6 @@ final fun (kotlinx.datetime/LocalTime).kotlinx.datetime/format(kotlinx.datetime.
 final fun (kotlinx.datetime/LocalTime.Companion).kotlinx.datetime/parseOrNull(kotlin/CharSequence, kotlinx.datetime.format/DateTimeFormat<kotlinx.datetime/LocalTime> = ...): kotlinx.datetime/LocalTime? // kotlinx.datetime/parseOrNull|parseOrNull@kotlinx.datetime.LocalTime.Companion(kotlin.CharSequence;kotlinx.datetime.format.DateTimeFormat<kotlinx.datetime.LocalTime>){}[0]
 final fun (kotlinx.datetime/TimeZone).kotlinx.datetime/offsetAt(kotlin.time/Instant): kotlinx.datetime/UtcOffset // kotlinx.datetime/offsetAt|offsetAt@kotlinx.datetime.TimeZone(kotlin.time.Instant){}[0]
 final fun (kotlinx.datetime/TimeZone).kotlinx.datetime/offsetAt(kotlinx.datetime/Instant): kotlinx.datetime/UtcOffset // kotlinx.datetime/offsetAt|offsetAt@kotlinx.datetime.TimeZone(kotlinx.datetime.Instant){}[0]
-final fun (kotlinx.datetime/TimeZone).kotlinx.datetime/offsetInfoFor(kotlinx.datetime/LocalDateTime): kotlinx.datetime/LocalDateTimeOffsetInfo // kotlinx.datetime/offsetInfoFor|offsetInfoFor@kotlinx.datetime.TimeZone(kotlinx.datetime.LocalDateTime){}[0]
 final fun (kotlinx.datetime/UtcOffset).kotlinx.datetime/asTimeZone(): kotlinx.datetime/FixedOffsetTimeZone // kotlinx.datetime/asTimeZone|asTimeZone@kotlinx.datetime.UtcOffset(){}[0]
 final fun (kotlinx.datetime/UtcOffset).kotlinx.datetime/format(kotlinx.datetime.format/DateTimeFormat<kotlinx.datetime/UtcOffset>): kotlin/String // kotlinx.datetime/format|format@kotlinx.datetime.UtcOffset(kotlinx.datetime.format.DateTimeFormat<kotlinx.datetime.UtcOffset>){}[0]
 final fun (kotlinx.datetime/UtcOffset.Companion).kotlinx.datetime/parseOrNull(kotlin/CharSequence, kotlinx.datetime.format/DateTimeFormat<kotlinx.datetime/UtcOffset> = ...): kotlinx.datetime/UtcOffset? // kotlinx.datetime/parseOrNull|parseOrNull@kotlinx.datetime.UtcOffset.Companion(kotlin.CharSequence;kotlinx.datetime.format.DateTimeFormat<kotlinx.datetime.UtcOffset>){}[0]

--- a/core/common/src/TimeZone.kt
+++ b/core/common/src/TimeZone.kt
@@ -67,6 +67,31 @@ public expect open class TimeZone {
     public val id: String
 
     /**
+     * Finds the offset from UTC this time zone has at the specified [instant] of physical time.
+     *
+     * **Pitfall**: the offset returned from this function should typically not be used for datetime arithmetics
+     * because the offset can change over time due to daylight-saving-time transitions and other reasons.
+     * Use [TimeZone] directly with arithmetic operations instead.
+     *
+     * @see Instant.toLocalDateTime
+     * @see TimeZone.offsetAt
+     * @sample kotlinx.datetime.test.samples.TimeZoneSamples.offsetAt
+     */
+    public fun offsetAt(instant: Instant): UtcOffset
+
+    /**
+     * Returns the [offset information][LocalDateTimeOffsetInfo] corresponding to the given [dateTime] in this time zone.
+     *
+     * See the [LocalDateTimeOffsetInfo] documentation for a detailed description.
+     *
+     * See [LocalDateTime.toInstant] together with [TransitionHandler] for a more streamlined way
+     * to handle a subset of this function's use cases.
+     *
+     * @sample kotlinx.datetime.test.samples.TimeZoneSamples.offsetInfoFor
+     */
+    public fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo
+
+    /**
      * Equivalent to [id].
      *
      * @sample kotlinx.datetime.test.samples.TimeZoneSamples.equalsSample
@@ -276,19 +301,6 @@ public expect class FixedOffsetTimeZone : TimeZone {
 @Deprecated("Use FixedOffsetTimeZone or UtcOffset instead", ReplaceWith("FixedOffsetTimeZone"))
 public typealias ZoneOffset = FixedOffsetTimeZone
 
-/**
- * Finds the offset from UTC this time zone has at the specified [instant] of physical time.
- *
- * **Pitfall**: the offset returned from this function should typically not be used for datetime arithmetics
- * because the offset can change over time due to daylight-saving-time transitions and other reasons.
- * Use [TimeZone] directly with arithmetic operations instead.
- *
- * @see Instant.toLocalDateTime
- * @see TimeZone.offsetAt
- * @sample kotlinx.datetime.test.samples.TimeZoneSamples.offsetAt
- */
-public expect fun TimeZone.offsetAt(instant: Instant): UtcOffset
-
 @Suppress("DEPRECATION")
 @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
     level = DeprecationLevel.WARNING,
@@ -351,7 +363,7 @@ public fun kotlinx.datetime.Instant.toLocalDateTime(offset: UtcOffset): LocalDat
  * @sample kotlinx.datetime.test.samples.TimeZoneSamples.offsetIn
  */
 public fun Instant.offsetIn(timeZone: TimeZone): UtcOffset =
-        timeZone.offsetAt(this)
+    timeZone.offsetAt(this)
 
 @Suppress("DEPRECATION")
 @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
@@ -455,18 +467,6 @@ public fun LocalDateTime.toInstant(
  * @sample kotlinx.datetime.test.samples.TimeZoneSamples.localDateTimeToInstantInFixedOffsetZone
  */
 public fun LocalDateTime.toInstant(timeZone: FixedOffsetTimeZone): Instant = toInstant(timeZone.offset)
-
-/**
- * Returns the [offset information][LocalDateTimeOffsetInfo] corresponding to the given [dateTime] in this time zone.
- *
- * See the [LocalDateTimeOffsetInfo] documentation for a detailed description.
- *
- * See [LocalDateTime.toInstant] together with [TransitionHandler] for a more streamlined way
- * to handle a subset of this function's use cases.
- *
- * @sample kotlinx.datetime.test.samples.TimeZoneSamples.offsetInfoFor
- */
-public expect fun TimeZone.offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo
 
 @PublishedApi
 @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "DEPRECATION")

--- a/core/common/src/internal/tz/RuleBasedTimeZoneCalculations.kt
+++ b/core/common/src/internal/tz/RuleBasedTimeZoneCalculations.kt
@@ -12,9 +12,9 @@ import kotlin.time.Instant
 internal class RuleBasedTimeZoneCalculations(
     private val tzid: TimeZoneRules, val id: String, val origin: Any?
 ) {
-    fun offsetInfoForImpl(dateTime: LocalDateTime): LocalDateTimeOffsetInfo = tzid.infoAtDatetime(dateTime)
+    fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo = tzid.infoAtDatetime(dateTime)
 
-    fun offsetAtImpl(instant: Instant): UtcOffset = tzid.infoAtInstant(instant)
+    fun offsetAt(instant: Instant): UtcOffset = tzid.infoAtInstant(instant)
 
     override fun equals(other: Any?): Boolean =
         other is RuleBasedTimeZoneCalculations && id == other.id && origin == other.origin

--- a/core/commonJs/src/internal/Platform.kt
+++ b/core/commonJs/src/internal/Platform.kt
@@ -97,16 +97,16 @@ private object SystemTimeZone: TimeZone() {
     override val id: String get() = "SYSTEM"
 
     /* https://github.com/js-joda/js-joda/blob/8c1a7448db92ca014417346049fb64b55f7b1ac1/packages/core/src/zone/SystemDefaultZoneRules.js#L21-L24 */
-    override fun offsetAtImpl(instant: Instant): UtcOffset =
+    override fun offsetAt(instant: Instant): UtcOffset =
         UtcOffset(minutes = -Date(instant.toEpochMilliseconds().toDouble()).getTimezoneOffset().toInt())
 
     // Assuming there are not going to be multiple transitions on the same day or transitions of 24 hours or longer
-    override fun offsetInfoForImpl(dateTime: LocalDateTime): LocalDateTimeOffsetInfo {
+    override fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo {
         val offsetGuess = Date(milliseconds = dateTime.toInstant(UTC).toEpochMilliseconds().toDouble())
             .getTimezoneOffset().toInt().let { UtcOffset(minutes = -it) }
         val instantGuess = dateTime.toInstant(offsetGuess)
-        val offsetBefore = offsetAtImpl(instantGuess - 24.hours)
-        val offsetAfter = offsetAtImpl(instantGuess + 24.hours)
+        val offsetBefore = offsetAt(instantGuess - 24.hours)
+        val offsetAfter = offsetAt(instantGuess + 24.hours)
         // No transitions (assuming no wild irregularities)
         if (offsetBefore == offsetAfter) return LocalDateTimeOffsetInfo.Regular(offsetGuess)
         // Binary search for the transition
@@ -114,7 +114,7 @@ private object SystemTimeZone: TimeZone() {
         var r = 24.hours.inWholeSeconds
         while (l != r) {
             val current = (l + r) / 2 // small values, no need for tricks
-            if (offsetAtImpl(instantGuess + current.seconds) == offsetBefore) {
+            if (offsetAt(instantGuess + current.seconds) == offsetBefore) {
                 l = current + 1
             } else {
                 r = current
@@ -182,4 +182,5 @@ internal actual val systemTimeZoneIdProvider: TimeZoneIdProvider = object: TimeZ
     override fun currentTimeZoneId(): String = currentTimeZoneIdImpl()
 }
 
+@OptIn(ExperimentalWasmJsInterop::class)
 private fun currentTimeZoneIdImpl(): String = js("Intl.DateTimeFormat().resolvedOptions().timeZone")

--- a/core/commonKotlin/src/TimeZone.kt
+++ b/core/commonKotlin/src/TimeZone.kt
@@ -83,14 +83,14 @@ public actual open class TimeZone internal constructor() {
     )
 
     internal open fun instantToLocalDateTime(instant: Instant): LocalDateTime = try {
-        instant.toLocalDateTimeImpl(offsetAtImpl(instant))
+        instant.toLocalDateTimeImpl(offsetAt(instant))
     } catch (e: IllegalArgumentException) {
         throw DateTimeArithmeticException("Instant $instant is not representable as LocalDateTime.", e)
     }
 
-    internal open fun offsetAtImpl(instant: Instant): UtcOffset = error("Should be overridden")
+    public actual open fun offsetAt(instant: Instant): UtcOffset = error("Should be overridden")
 
-    internal open fun offsetInfoForImpl(dateTime: LocalDateTime): LocalDateTimeOffsetInfo = error("Should be overridden")
+    public actual open fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo = error("Should be overridden")
 
     internal open fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset? = null): Instant =
         localDateTimeToInstantLenient(dateTime, this, TransitionHandler.USE_OFFSET_BEFORE, preferred)
@@ -114,9 +114,9 @@ public actual class FixedOffsetTimeZone internal constructor(public actual val o
     override fun atStartOfDay(date: LocalDate): Instant =
         LocalDateTime(date, LocalTime.MIN).toInstant(offset)
 
-    override fun offsetAtImpl(instant: Instant): UtcOffset = offset
+    override fun offsetAt(instant: Instant): UtcOffset = offset
 
-    override fun offsetInfoForImpl(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
+    override fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
         LocalDateTimeOffsetInfo.Regular(offset)
 
     override fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset?): Instant =
@@ -144,9 +144,9 @@ public actual class FixedOffsetTimeZone internal constructor(public actual val o
     }
 }
 
-
-public actual fun TimeZone.offsetAt(instant: Instant): UtcOffset =
-    offsetAtImpl(instant)
+@PublishedApi
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+internal fun TimeZone.offsetAt(instant: Instant): UtcOffset = offsetAt(instant) // member shadows the extension
 
 public actual fun Instant.toLocalDateTime(timeZone: TimeZone): LocalDateTime =
     timeZone.instantToLocalDateTime(this)
@@ -180,7 +180,4 @@ public actual fun LocalDate.atStartOfDayIn(timeZone: TimeZone, youShallNotPass: 
 
 internal actual fun LocalDateTime.optimizedToInstantOffsetBefore(timeZone: TimeZone): Instant =
     timeZone.localDateTimeToInstant(this)
-
-public actual fun TimeZone.offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
-    offsetInfoForImpl(dateTime)
 

--- a/core/commonKotlin/src/internal/systemTimeZoneContext.kt
+++ b/core/commonKotlin/src/internal/systemTimeZoneContext.kt
@@ -11,10 +11,10 @@ import kotlin.time.Instant
 internal class RuleBasedTimeZone(private val calculations: RuleBasedTimeZoneCalculations): TimeZone() {
     override val id: String get() = calculations.id
 
-    override fun offsetAtImpl(instant: Instant): UtcOffset = calculations.offsetAtImpl(instant)
+    override fun offsetAt(instant: Instant): UtcOffset = calculations.offsetAt(instant)
 
-    override fun offsetInfoForImpl(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
-        calculations.offsetInfoForImpl(dateTime)
+    override fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
+        calculations.offsetInfoFor(dateTime)
 
     override fun equals(other: Any?): Boolean =
         other is RuleBasedTimeZone && calculations == other.calculations

--- a/core/jvm/src/TimeZoneJvm.kt
+++ b/core/jvm/src/TimeZoneJvm.kt
@@ -20,6 +20,11 @@ import kotlin.time.toKotlinInstant
 public actual open class TimeZone internal constructor(internal val zoneId: ZoneIdLike) {
     public actual val id: String get() = zoneId.id
 
+    public actual fun offsetAt(instant: Instant): UtcOffset =
+        zoneId.offsetAt(instant)
+
+    public actual fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
+        zoneId.offsetInfoFor(dateTime)
 
     // experimental member-extensions
     public actual fun Instant.toLocalDateTime(): LocalDateTime = toLocalDateTime(this@TimeZone)
@@ -133,7 +138,10 @@ internal constructor(public actual val offset: UtcOffset, zoneId: ZoneId): TimeZ
     }
 }
 
-public actual fun TimeZone.offsetAt(instant: Instant): UtcOffset =
+// compatibility with 0.8.0
+@PublishedApi
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+internal fun TimeZone.offsetAt(instant: Instant): UtcOffset =
     zoneId.offsetAt(instant)
 
 public actual fun Instant.toLocalDateTime(timeZone: TimeZone): LocalDateTime =
@@ -163,9 +171,6 @@ public actual fun LocalDateTime.toInstant(offset: UtcOffset, youShallNotPass: Ov
 @Suppress("DEPRECATION_ERROR")
 public actual fun LocalDate.atStartOfDayIn(timeZone: TimeZone, youShallNotPass: OverloadMarker): Instant =
     timeZone.zoneId.atStartOfDay(this)
-
-public actual fun TimeZone.offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
-    zoneId.offsetInfoFor(dateTime)
 
 internal sealed interface ZoneIdLike {
     val id: String
@@ -224,10 +229,10 @@ internal sealed interface ZoneIdLike {
         override val id: String get() = zoneRules.id
 
         override fun offsetAt(instant: Instant): UtcOffset =
-            zoneRules.offsetAtImpl(instant)
+            zoneRules.offsetAt(instant)
 
         override fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
-            zoneRules.offsetInfoForImpl(dateTime)
+            zoneRules.offsetInfoFor(dateTime)
 
         override fun atStartOfDay(date: LocalDate): Instant {
             val ldt = LocalDateTime(date, LocalTime.MIN)


### PR DESCRIPTION
This commit moves `offsetAt` and `offsetInfoFor` to be members of `TimeZone`.
This highlights these two methods being fundamental to `TimeZone`, with all the other methods we provide being derived from them.