### PR TITLE
Fix `DateTimePeriod.parse` not handling an overflow in `weeks * 7`

### DIFF
--- a/core/common/src/DateTimePeriod.kt
+++ b/core/common/src/DateTimePeriod.kt
@@ -331,7 +331,7 @@ public sealed class DateTimePeriod {
                         parseException("Unexpected end of input; 'P' designator is required", i)
                     if (state == AFTER_T)
                         parseException("Unexpected end of input; at least one time component is required after 'T'", i)
-                    val daysTotal = when (val n = days.toLong() + weeks * 7) {
+                    val daysTotal = when (val n = days.toLong() + weeks.toLong() * 7) {
                         in Int.MIN_VALUE..Int.MAX_VALUE -> n.toInt()
                         else -> parseException("The total number of days under 'D' and 'W' designators should fit into an Int", 0)
                     }

--- a/core/common/test/DateTimePeriodTest.kt
+++ b/core/common/test/DateTimePeriodTest.kt
@@ -125,6 +125,9 @@ class DateTimePeriodTest {
         assertFailsToParse<IllegalArgumentException>("P1Y9223372036854775805M")
         assertFailsToParse<IllegalArgumentException>("PT+-2H")
 
+        // overflow of `Int.MAX_VALUE` days when `weeks * 7` are overflowing an `Int`
+        assertFailsToParse<IllegalArgumentException>("P613566757W")
+
         // Failing parsing tests - DateTimeFormatException
         assertFailsToParse<DateTimeFormatException>("P3000000000Y")
         assertFailsToParse<DateTimeFormatException>("P3000000000M")


### PR DESCRIPTION
Fixes #644