### PR TITLE
Fix `LocalDate.toLocalIsoWeekDate` throwing in the last supported year

### DIFF
--- a/core/common/src/LocalIsoWeekDate.kt
+++ b/core/common/src/LocalIsoWeekDate.kt
@@ -432,8 +432,8 @@ public fun LocalDate.toLocalIsoWeekDate(): LocalIsoWeekDate {
             isoWeekYear = year - 1
             startOfIsoWeekYear(isoWeekYear)
         } else {
-            val nextYear = startOfIsoWeekYear(year + 1)
-            if (this >= nextYear) {
+            val nextYear = if (year < YEAR_MAX) startOfIsoWeekYear(year + 1) else null
+            if (nextYear != null && this >= nextYear) {
                 isoWeekYear = year + 1
                 nextYear
             } else {

--- a/core/common/test/LocalIsoWeekDateTest.kt
+++ b/core/common/test/LocalIsoWeekDateTest.kt
@@ -86,6 +86,31 @@ class LocalIsoWeekDateTest {
     }
 
     @Test
+    fun conversionAtTheEndsOfTheSupportedRange() {
+        val table = listOf(
+            LocalDate(YEAR_MIN, 1, 1) to "-999999999-W01-1",
+            LocalDate(YEAR_MIN, 12, 31) to "-999999998-W01-1",
+            LocalDate(YEAR_MAX - 1, 12, 31) to "+999999998-W53-4",
+            LocalDate(YEAR_MAX, 1, 1) to "+999999998-W53-5",
+            LocalDate(YEAR_MAX, 1, 3) to "+999999998-W53-7",
+            LocalDate(YEAR_MAX, 1, 4) to "+999999999-W01-1",
+            LocalDate(YEAR_MAX, 12, 31) to "+999999999-W52-5",
+        )
+        for ((date, weekDateString) in table) {
+            val weekDate = date.toLocalIsoWeekDate()
+            assertEquals(weekDateString, weekDate.toString())
+            assertEquals(date, weekDate.toLocalDate())
+            assertEquals(weekDate, LocalIsoWeekDate.parse(weekDateString))
+        }
+        for (date in LocalDate(YEAR_MIN, 1, 1)..LocalDate(YEAR_MIN, 12, 31)) {
+            assertEquals(date, date.toLocalIsoWeekDate().toLocalDate())
+        }
+        for (date in LocalDate(YEAR_MAX, 1, 1)..LocalDate(YEAR_MAX, 12, 31)) {
+            assertEquals(date, date.toLocalIsoWeekDate().toLocalDate())
+        }
+    }
+
+    @Test
     fun parsing() {
         fun checkComponents(weekDate: LocalIsoWeekDate, year: Int, week: Int, dayOfWeek: DayOfWeek) {
             assertEquals(year, weekDate.isoWeekYear)

--- a/core/jvm/test/LocalIsoWeekDateTest.kt
+++ b/core/jvm/test/LocalIsoWeekDateTest.kt
@@ -3,20 +3,32 @@ package kotlinx.datetime
 import kotlin.test.*
 
 class LocalIsoWeekDateTestJvm {
+    private val maxDay =
+        -java.time.LocalDate.MAX.until(java.time.LocalDate.ofEpochDay(0), java.time.temporal.ChronoUnit.DAYS)
+    private val minDay =
+        -java.time.LocalDate.MIN.until(java.time.LocalDate.ofEpochDay(0), java.time.temporal.ChronoUnit.DAYS)
+
+    private fun assertSameAsJavaTime(epochDay: Long) {
+        val jvmDate = java.time.LocalDate.ofEpochDay(epochDay)
+        val ktDate = LocalDate.fromEpochDays(epochDay)
+        val weekDateString = java.time.format.DateTimeFormatter.ISO_WEEK_DATE.format(jvmDate)
+        val yearWeekDate = LocalIsoWeekDate.parse(weekDateString)
+        assertEquals(weekDateString, yearWeekDate.toString())
+        assertEquals(yearWeekDate, ktDate.toLocalIsoWeekDate())
+        assertEquals(ktDate, yearWeekDate.toLocalDate())
+    }
+
     // Check that we agree with Java.Time regarding which dates correspond to which LocalIsoWeekDates
     @Test
     fun randomizedJavaCompatibilityTest() {
-        val maxDay = -java.time.LocalDate.MAX.until(java.time.LocalDate.ofEpochDay(0), java.time.temporal.ChronoUnit.DAYS)
-        val minDay = -java.time.LocalDate.MIN.until(java.time.LocalDate.ofEpochDay(0), java.time.temporal.ChronoUnit.DAYS)
         repeat(100000) {
-            val randomDay = kotlin.random.Random.nextLong(minDay, maxDay)
-            val jvmDate = java.time.LocalDate.ofEpochDay(randomDay)
-            val ktDate = LocalDate.fromEpochDays(randomDay)
-            val weekDateString = java.time.format.DateTimeFormatter.ISO_WEEK_DATE.format(jvmDate)
-            val yearWeekDate = LocalIsoWeekDate.parse(weekDateString)
-            assertEquals(weekDateString, yearWeekDate.toString())
-            assertEquals(yearWeekDate, ktDate.toLocalIsoWeekDate())
-            assertEquals(ktDate, yearWeekDate.toLocalDate())
+            assertSameAsJavaTime(kotlin.random.Random.nextLong(minDay, maxDay + 1))
         }
+    }
+
+    @Test
+    fun boundaryJavaCompatibilityTest() {
+        for (epochDay in minDay..minDay + 800) assertSameAsJavaTime(epochDay)
+        for (epochDay in maxDay - 800..maxDay) assertSameAsJavaTime(epochDay)
     }
 }


### PR DESCRIPTION
`toLocalIsoWeekDate` documents that it never throws, but it throws `IllegalArgumentException` for every date from `+999999999-01-04` through `+999999999-12-31`, so 362 days at the top of the `LocalDate` range have no week-date representation:

```kotlin
LocalDate(999_999_999, 6, 15).toLocalIsoWeekDate()
// IllegalArgumentException: Invalid value for Year (valid values -999999999 - 999999999): 1000000000
```

The `else` branch evaluates `startOfIsoWeekYear(year + 1)` before checking whether it is needed. When `year` is already `YEAR_MAX` that builds `LocalDate(1000000000, 1, 4)`, which is out of range. The week-year can never roll over there anyway: the next week-year starts at `+1000000000-01-03`, past `LocalDate.MAX`, so the answer is always `year`. I made the computation conditional.

The bottom of the range is fine by a margin of zero days, since `-999999999-01-01` happens to be a Monday and is therefore exactly the start of week-year `-999999999`. I added tests there too so it stays that way.

Oracle is `java.time` (`IsoFields` via `DateTimeFormatter.ISO_WEEK_DATE`). The existing randomized JVM test drew from `Random.nextLong(minDay, maxDay)`, which is exclusive at the top, so `LocalDate.MAX` was never reachable and 100000 random draws from ~730 billion days never landed in the final year. I made that bound inclusive and added an exhaustive check of the first and last 801 days against `java.time`, which covers the whole broken region. The common test pins seven boundary dates and round-trips both extreme years day by day, so Native and JS are covered as well, where `java.time` is not available.

Verified fail-before/pass-after by reverting only `LocalIsoWeekDate.kt` and keeping the tests: both new tests fail, and the full `jvmTest` suite is 599 tests green with the fix. Built and tested locally on JVM only; I did not run the Native or JS targets.

I used Claude Code to help find and fix this.