### PR TITLE
Remove usages of deprecated macosX64, tvosX64, watchosX64 targets

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -48,11 +48,8 @@ kotlin {
                             }
                             group("darwin") {
                                 group("darwinDevices") {
-                                    withMacosX64()
                                     withMacosArm64()
-                                    withWatchosX64()
                                     withWatchosArm64()
-                                    withTvosX64()
                                     withTvosArm64()
                                     withIosArm64()
                                     withWatchosDeviceArm64()
@@ -143,13 +140,6 @@ kotlin {
     watchosDeviceArm64()
     // Deprecated, preserved for KT-58864
     @Suppress("DEPRECATION") linuxArm32Hfp()
-    // Deprecated for removal: KT-78660
-    @Suppress("DEPRECATION", "DEPRECATION_ERROR")
-    run {
-        macosX64()
-        watchosX64()
-        tvosX64()
-    }
 
     @OptIn(ExperimentalKotlinGradlePluginApi::class)
     compilerOptions {

--- a/integration-testing/serialization/build.gradle.kts
+++ b/integration-testing/serialization/build.gradle.kts
@@ -37,13 +37,6 @@ kotlin {
     watchosDeviceArm64()
     // Deprecated, preserved for KT-58864
     @Suppress("DEPRECATION") linuxArm32Hfp()
-    // Deprecated for removal: KT-78660
-    @Suppress("DEPRECATION", "DEPRECATION_ERROR")
-    run {
-        macosX64()
-        watchosX64()
-        tvosX64()
-    }
 
     jvm {
         attributes {

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -33,13 +33,6 @@ kotlin {
     watchosDeviceArm64()
     // Deprecated, preserved for KT-58864
     @Suppress("DEPRECATION") linuxArm32Hfp()
-    // Deprecated for removal: KT-78660
-    @Suppress("DEPRECATION", "DEPRECATION_ERROR")
-    run {
-        macosX64()
-        watchosX64()
-        tvosX64()
-    }
 
     jvm {
         attributes {


### PR DESCRIPTION
These targets are deprecated in Kotlin 2.5.0, see KT-84955.