### PR TITLE
Fix ZZZZZ not using Z for the zero UTC offset

### DIFF
--- a/core/common/src/format/Unicode.kt
+++ b/core/common/src/format/Unicode.kt
@@ -578,7 +578,7 @@ internal sealed interface UnicodeFormat {
                     when (formatLength) {
                         1, 2, 3 -> builder.offset(zOnZero = false, useSeparator = false)
                         4 -> LocalizedZoneOffset(4).addToFormat(builder)
-                        5 -> builder.offset(zOnZero = false, useSeparator = true)
+                        5 -> builder.offset(zOnZero = true, useSeparator = true)
                         else -> unknownLength()
                     }
                 }

--- a/core/jvm/test/UnicodeFormatTest.kt
+++ b/core/jvm/test/UnicodeFormatTest.kt
@@ -40,18 +40,11 @@ class UnicodeFormatTest {
             "yyyy_MM_dd_HH_mm_ss", "yyyy-MM-d 'at' HH:mm ", "yyyy:MM:dd HH:mm:ss",
             "yyyy年MM月dd日 HH:mm:ss", "yyyy年MM月dd日", "dd.MM.yyyy. HH:mm:ss", "ss", "ddMMyyyy",
             "yyyyMMdd'T'HHmmss'Z'", "yyyyMMdd'T'HHmmss", "yyyy-MM-dd'T'HH:mm:ssX",
-            // every supported UTC-offset directive, at every supported length.
-            // `x` alone is omitted: Java parses its own output "+0001" as just "+00", because the
-            // no-offset text of `x` is "+00" and it greedily matches that prefix.
-            "X", "XX", "XXX", "XXXX", "XXXXX",
-            "xx", "xxx", "xxxx", "xxxxx",
-            "Z", "ZZ", "ZZZ", "ZZZZZ",
         )
         val localizedPatterns = listOf(
             "MMMM", "hh:mm a", "h:mm a", "dd MMMM yyyy", "dd MMM yyyy", "yyyy-MM-dd hh:mm:ss", "d MMMM yyyy", "MMM",
             "MMM dd, yyyy", "dd-MMM-yyyy", "d MMM yyyy", "MMM yyyy", "MMMM yyyy", "EEE", "EEEE", "hh:mm:ss a",
             "d MMM uuuu HH:mm:ss ", "MMMM d, yyyy", "MMMM dd, yyyy", "yyyy-MM-dd HH:mm:ss z", "hh:mm", "MMM dd",
-            "ZZZZ", // localized GMT offset, same as `OOOO`
         )
         val unsupportedPatterns = listOf(
             "YYYY-MM-dd",
@@ -64,6 +57,32 @@ class UnicodeFormatTest {
                 }
             }
         }
+        for (pattern in localizedPatterns) {
+            val error = assertFailsWith<IllegalArgumentException> {
+                DateTimeComponents.Format {
+                    byUnicodePattern(pattern)
+                }
+            }
+            assertContains(error.message!!, "locale-dependent")
+        }
+        for (pattern in nonLocalizedPatterns) {
+            checkPattern(pattern)
+        }
+    }
+
+    @Test
+    fun testUtcOffsetFormats() {
+        // every supported UTC-offset directive, at every supported length.
+        // `x` alone is omitted: Java parses its own output "+0001" as just "+00", because the
+        // no-offset text of `x` is "+00" and it greedily matches that prefix.
+        val nonLocalizedPatterns = listOf(
+            "X", "XX", "XXX", "XXXX", "XXXXX",
+            "xx", "xxx", "xxxx", "xxxxx",
+            "Z", "ZZ", "ZZZ", "ZZZZZ",
+        )
+        val localizedPatterns = listOf(
+            "ZZZZ", // localized GMT offset, same as `OOOO`
+        )
         for (pattern in localizedPatterns) {
             val error = assertFailsWith<IllegalArgumentException> {
                 DateTimeComponents.Format {

--- a/core/jvm/test/UnicodeFormatTest.kt
+++ b/core/jvm/test/UnicodeFormatTest.kt
@@ -40,11 +40,18 @@ class UnicodeFormatTest {
             "yyyy_MM_dd_HH_mm_ss", "yyyy-MM-d 'at' HH:mm ", "yyyy:MM:dd HH:mm:ss",
             "yyyy年MM月dd日 HH:mm:ss", "yyyy年MM月dd日", "dd.MM.yyyy. HH:mm:ss", "ss", "ddMMyyyy",
             "yyyyMMdd'T'HHmmss'Z'", "yyyyMMdd'T'HHmmss", "yyyy-MM-dd'T'HH:mm:ssX",
+            // every supported UTC-offset directive, at every supported length.
+            // `x` alone is omitted: Java parses its own output "+0001" as just "+00", because the
+            // no-offset text of `x` is "+00" and it greedily matches that prefix.
+            "X", "XX", "XXX", "XXXX", "XXXXX",
+            "xx", "xxx", "xxxx", "xxxxx",
+            "Z", "ZZ", "ZZZ", "ZZZZZ",
         )
         val localizedPatterns = listOf(
             "MMMM", "hh:mm a", "h:mm a", "dd MMMM yyyy", "dd MMM yyyy", "yyyy-MM-dd hh:mm:ss", "d MMMM yyyy", "MMM",
             "MMM dd, yyyy", "dd-MMM-yyyy", "d MMM yyyy", "MMM yyyy", "MMMM yyyy", "EEE", "EEEE", "hh:mm:ss a",
             "d MMM uuuu HH:mm:ss ", "MMMM d, yyyy", "MMMM dd, yyyy", "yyyy-MM-dd HH:mm:ss z", "hh:mm", "MMM dd",
+            "ZZZZ", // localized GMT offset, same as `OOOO`
         )
         val unsupportedPatterns = listOf(
             "YYYY-MM-dd",


### PR DESCRIPTION
`byUnicodePattern("ZZZZZ")` formats the zero UTC offset as `+00:00` and cannot parse `Z` back. It should produce `Z` in both directions, since `zOnZero` drives `isoOffset`, which governs formatting and parsing alike.

The length-5 branch of `ZoneOffset3` (`'Z'`) is byte-identical to the length-5 branch of `ZoneOffset2` (`'x'`) just above it, where `zOnZero = false` *is* correct. It reads as a copy-paste that carried `x` semantics onto `Z`.

Two sources agree on `Z`:

- **java.time** (JDK 21): `ZZZZZ` at zero gives `Z`, at `+01:30` gives `+01:30`. The `DateTimeFormatter` javadoc for five `Z` letters: *"It outputs 'Z' if the offset is zero."*
- **The KDoc table in `Unicode.kt` itself**, which already documents ``| `XXXXX`, `ZZZZZ` | always | unless zero | colon | `Z` |``. The file documents `Z` and implements `+00:00`.

The line and that contradicting doc row were introduced together in `f18cb89`, with no rationale for `ZZZZZ` in the commit.

Full `X`/`x`/`Z` by lengths 1-5 grid against java.time: **exactly one cell diverges**, which is why the diff is one token. `ZZZZ` is not a divergence — java.time's `ZZZZ` is the localized `GMT+01:30` form and kotlinx correctly refuses it as locale-dependent; I moved it to `localizedPatterns` to pin that.

**Test.** The bug survived because the pattern corpus in `UnicodeFormatTest`, which already formats with both engines and asserts equality, contains no `ZZZZZ`. Rather than add the one cell, this adds every offset directive at every supported length.

The naive fix, `zOnZero = true` for *all* `Z` lengths, fails 2 tests, since `Z`/`ZZ`/`ZZZ` must stay `+0000`. Reverting only `Unicode.kt` makes the new corpus fail with `expected:<+00:00> but was:<Z>`, and nothing else moves.

No new API; `jvmApiCheck` passes. Full `jvmTest`: 599 tests, 0 failures, 4 pre-existing skips.

---
Drafted with the assistance of Claude Opus 5 (`claude-opus-5`); I have reviewed and verified every change and the measurements above.
