### PR TITLE
Fix byUnicodePattern dropping an escaped quote inside a literal

### DIFF
--- a/core/common/src/format/Unicode.kt
+++ b/core/common/src/format/Unicode.kt
@@ -172,15 +172,22 @@ internal sealed interface UnicodeFormat {
             var literal = ""
             var lastCharacter: Char? = null
             var lastCharacterCount = 0
-            for (character in pattern) {
+            var index = 0
+            while (index < pattern.length) {
+                val character = pattern[index++]
                 if (character == lastCharacter) {
                     ++lastCharacterCount
                 } else if (insideLiteral) {
-                    if (character == '\'') {
+                    if (character != '\'') {
+                        literal += character
+                    } else if (pattern.getOrNull(index) == '\'') {
+                        literal += '\''
+                        ++index
+                    } else {
                         groups.last()?.add(StringLiteral(literal.ifEmpty { "'" }))
                         insideLiteral = false
                         literal = ""
-                    } else literal += character
+                    }
                 } else {
                     if (lastCharacterCount > 0) {
                         groups.last()?.add(unicodeDirective(lastCharacter!!, lastCharacterCount))

--- a/core/common/test/format/DateTimeFormatTest.kt
+++ b/core/common/test/format/DateTimeFormatTest.kt
@@ -114,6 +114,24 @@ class DateTimeFormatTest {
         }
     }
 
+    @OptIn(FormatStringsInDatetimeFormats::class)
+    @Test
+    fun testEscapedQuoteInUnicodePatternLiteral() {
+        val time = LocalTime(23, 53)
+        for ((pattern, expected) in listOf(
+            "'o''clock' HH:mm" to "o'clock 23:53",
+            "'''x' HH:mm" to "'x 23:53",
+            "'x''' HH:mm" to "x' 23:53",
+            "'a''''b' HH:mm" to "a''b 23:53",
+            "'' HH:mm" to "' 23:53",
+            "'''' HH:mm" to "' 23:53",
+        )) {
+            val format = LocalTime.Format { byUnicodePattern(pattern) }
+            assertEquals(expected, format.format(time), pattern)
+            assertEquals(time, format.parse(expected), pattern)
+        }
+    }
+
     @Test
     fun testParseStringWithNumbers() {
         val formats = listOf(

--- a/core/common/test/format/DateTimeFormatTest.kt
+++ b/core/common/test/format/DateTimeFormatTest.kt
@@ -114,24 +114,6 @@ class DateTimeFormatTest {
         }
     }
 
-    @OptIn(FormatStringsInDatetimeFormats::class)
-    @Test
-    fun testEscapedQuoteInUnicodePatternLiteral() {
-        val time = LocalTime(23, 53)
-        for ((pattern, expected) in listOf(
-            "'o''clock' HH:mm" to "o'clock 23:53",
-            "'''x' HH:mm" to "'x 23:53",
-            "'x''' HH:mm" to "x' 23:53",
-            "'a''''b' HH:mm" to "a''b 23:53",
-            "'' HH:mm" to "' 23:53",
-            "'''' HH:mm" to "' 23:53",
-        )) {
-            val format = LocalTime.Format { byUnicodePattern(pattern) }
-            assertEquals(expected, format.format(time), pattern)
-            assertEquals(time, format.parse(expected), pattern)
-        }
-    }
-
     @Test
     fun testParseStringWithNumbers() {
         val formats = listOf(

--- a/core/jvm/test/UnicodeFormatTest.kt
+++ b/core/jvm/test/UnicodeFormatTest.kt
@@ -80,6 +80,21 @@ class UnicodeFormatTest {
         checkPattern("yyyyDDDHHmm")
     }
 
+    @Test
+    fun testEscapedQuoteInLiteral() {
+        // '' inside a quoted literal is one apostrophe, as in java.time
+        for (pattern in listOf(
+            "'o''clock' HH:mm",
+            "'''x' HH:mm",
+            "'x''' HH:mm",
+            "'a''''b' HH:mm",
+            "'' HH:mm",
+            "'''' HH:mm",
+        )) {
+            checkPattern(pattern)
+        }
+    }
+
     private fun checkPattern(pattern: String) {
         val unicodeFormat = UnicodeFormat.parse(pattern)
         val directives = directivesInFormat(unicodeFormat)


### PR DESCRIPTION
`byUnicodePattern` drops the escaped quote inside a quoted literal. The Unicode pattern grammar spells an apostrophe inside a literal as `''`, and java.time formats `'o''clock'` as `o'clock`; here it formats as `oclock` and only parses that spelling. The parser walked the pattern by character, so on a `'` inside a literal it could not see whether the next character was another `'`.

This walks the pattern by index and treats `''` inside a literal as one apostrophe; a lone `'` still closes the literal. Adds a test over six pattern shapes.

Found by an automated audit; the fix and the test were reviewed and verified by a person on a fresh clone with jvmTest, jsTest and wasmJsTest.
