### PR TITLE
Fix ReplaceWith on deprecated Instant.toEpochMilliseconds and isDistantFuture

### DIFF
--- a/core/common/src/DeprecatedInstant.kt
+++ b/core/common/src/DeprecatedInstant.kt
@@ -98,7 +98,7 @@ public expect class Instant : Comparable<Instant> {
      */
     @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
         level = DeprecationLevel.WARNING,
-        replaceWith = ReplaceWith("this.toStdlibInstant().nanosecondsOfSecond")
+        replaceWith = ReplaceWith("this.toStdlibInstant().toEpochMilliseconds()")
     )
     public fun toEpochMilliseconds(): Long
 
@@ -319,7 +319,7 @@ public val Instant.isDistantPast: Boolean
  */
 @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
     level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("this.toStdlibInstant().isDistantPast", "kotlin.time.isDistantFuture")
+    replaceWith = ReplaceWith("this.toStdlibInstant().isDistantFuture", "kotlin.time.isDistantFuture")
 )
 public val Instant.isDistantFuture: Boolean
     get() = this >= Instant.DISTANT_FUTURE

--- a/core/commonKotlin/src/DeprecatedInstant.kt
+++ b/core/commonKotlin/src/DeprecatedInstant.kt
@@ -57,7 +57,7 @@ public actual class Instant internal constructor(
 
     @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
         level = DeprecationLevel.WARNING,
-        replaceWith = ReplaceWith("this.toStdlibInstant().nanosecondsOfSecond")
+        replaceWith = ReplaceWith("this.toStdlibInstant().toEpochMilliseconds()")
     )
     // org.threeten.bp.Instant#toEpochMilli
     public actual fun toEpochMilliseconds(): Long = try {

--- a/core/jvm/src/DeprecatedInstant.kt
+++ b/core/jvm/src/DeprecatedInstant.kt
@@ -42,7 +42,7 @@ public actual class Instant internal constructor(internal val value: java.time.I
 
     @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
         level = DeprecationLevel.WARNING,
-        replaceWith = ReplaceWith("this.toStdlibInstant().nanosecondsOfSecond")
+        replaceWith = ReplaceWith("this.toStdlibInstant().toEpochMilliseconds()")
     )
     public actual fun toEpochMilliseconds(): Long = try {
         value.toEpochMilli()


### PR DESCRIPTION
Two `ReplaceWith` expressions on the deprecated `kotlinx.datetime.Instant` name a different member than the one they annotate. `toEpochMilliseconds()` offers `this.toStdlibInstant().nanosecondsOfSecond` as its replacement, in the `expect` declaration and both `actual` ones, and `isDistantFuture` offers `this.toStdlibInstant().isDistantPast`. An IDE quick-fix applied to either changes the program's result and leaves no warning behind.

This corrects the four expressions to the same-named member on `kotlin.time.Instant`. Annotation-only, so no test.

Found by an automated audit; the change was reviewed and verified by a person on a fresh clone with jvmTest, jsTest and wasmJsTest.
