### PR TITLE
Commonize `TimeZone`

### DIFF
--- a/benchmarks/src/jmh/kotlin/FixedOffsetTimeZoneOperations.kt
+++ b/benchmarks/src/jmh/kotlin/FixedOffsetTimeZoneOperations.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019-2026 JetBrains s.r.o. and contributors.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.datetime
+
+import org.openjdk.jmh.annotations.*
+import java.time.ZoneId
+import java.util.concurrent.TimeUnit
+import kotlin.time.Clock
+import kotlin.time.toJavaInstant
+
+enum class FixedOffsetTimeZoneParam(val timeZone: FixedOffsetTimeZone, val zoneId: ZoneId) {
+    UTC(TimeZone.UTC, ZoneId.of("UTC")),
+    UTC_PLUS_1_10_15(TimeZoneContext.System.get("UTC+01:10:15") as FixedOffsetTimeZone, ZoneId.of("UTC+01:10:15")),
+    GMT(TimeZoneContext.System.get("GMT") as FixedOffsetTimeZone, ZoneId.of("GMT")),
+    GMT_PLUS_1_10_15(TimeZoneContext.System.get("GMT+01:10:15") as FixedOffsetTimeZone, ZoneId.of("GMT+01:10:15")),
+}
+
+enum class UtcOffsetParam(val offset: UtcOffset) {
+    UTC(UtcOffset.ZERO),
+    UTC_PLUS_1_30_15(UtcOffset(1, 10, 15)),
+}
+
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+open class FixedOffsetTimeZoneConstruction {
+    @Param lateinit var timeZone: UtcOffsetParam
+
+    @Benchmark
+    fun construct() = FixedOffsetTimeZone(timeZone.offset)
+}
+
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+open class FixedOffsetTimeZoneUnaryOperations {
+    @Param lateinit var timeZone: FixedOffsetTimeZoneParam
+
+    @Benchmark
+    fun id() = timeZone.timeZone.id
+
+    @Benchmark
+    fun convertToKotlin() = timeZone.zoneId.toKotlinTimeZone()
+
+    @Benchmark
+    fun convertToJava() = timeZone.timeZone.toJavaZoneId()
+
+    @Benchmark
+    fun hashCodeImpl() = timeZone.timeZone.hashCode()
+
+    @Benchmark
+    fun toStringImpl() = timeZone.timeZone.toString()
+}
+
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+open class FixedOffsetTimeZoneBinaryOperations {
+    @Param lateinit var timeZone: FixedOffsetTimeZoneParam
+    @Param lateinit var otherTimeZone: FixedOffsetTimeZoneParam
+
+    @Benchmark
+    fun equalsImpl() = timeZone.timeZone == otherTimeZone.timeZone
+}
+
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+open class FixedOffsetTimeZoneQueryOperations {
+    @Param lateinit var timeZone: FixedOffsetTimeZoneParam
+    val dateToday = Clock.System.todayIn(TimeZone.UTC)
+    val javaDateToday = dateToday.toJavaLocalDate()
+    val dateTimeToday = dateToday.atTime(12, 30)
+    val javaDateTimeToday = dateTimeToday.toJavaLocalDateTime()
+    val instantToday = Clock.System.now()
+    val javaInstantToday = instantToday.toJavaInstant()
+
+    @Benchmark
+    fun atStartOfDayKotlin() = dateToday.atStartOfDayIn(timeZone.timeZone)
+
+    @Benchmark
+    fun atStartOfDayJava() = javaDateToday.atStartOfDay(timeZone.zoneId).toInstant()
+
+    @Benchmark
+    fun localDateTimeToInstantKotlin() = dateTimeToday.toInstant(timeZone.timeZone, TransitionHandler.USE_OFFSET_BEFORE)
+
+    @Benchmark
+    fun localDateTimeToInstantJava() = javaDateTimeToday.atZone(timeZone.zoneId).toInstant()
+
+    @Benchmark
+    fun instantToLocalDateTimeKotlin() = instantToday.toLocalDateTime(timeZone.timeZone)
+
+    @Benchmark
+    fun instantToLocalDateTimeJava() = javaInstantToday.atZone(timeZone.zoneId).toLocalDateTime()
+
+    @Benchmark
+    fun offsetInKotlin() = instantToday.offsetIn(timeZone.timeZone)
+
+    @Benchmark
+    fun offsetInJava() = timeZone.zoneId.rules.getOffset(javaInstantToday)
+
+    @Benchmark
+    fun offsetInfoForKotlin() = timeZone.timeZone.offsetInfoFor(dateTimeToday)
+
+    @Benchmark
+    // similar enough
+    fun offsetInfoForJava() = timeZone.zoneId.rules.getValidOffsets(javaDateTimeToday)
+}

--- a/core/api/kotlinx-datetime.klib.api
+++ b/core/api/kotlinx-datetime.klib.api
@@ -460,6 +460,7 @@ final class kotlinx.datetime/FixedOffsetTimeZone : kotlinx.datetime/TimeZone { /
     final fun hashCode(): kotlin/Int // kotlinx.datetime/FixedOffsetTimeZone.hashCode|hashCode(){}[0]
     final fun offsetAt(kotlin.time/Instant): kotlinx.datetime/UtcOffset // kotlinx.datetime/FixedOffsetTimeZone.offsetAt|offsetAt(kotlin.time.Instant){}[0]
     final fun offsetInfoFor(kotlinx.datetime/LocalDateTime): kotlinx.datetime/LocalDateTimeOffsetInfo // kotlinx.datetime/FixedOffsetTimeZone.offsetInfoFor|offsetInfoFor(kotlinx.datetime.LocalDateTime){}[0]
+    final fun toString(): kotlin/String // kotlinx.datetime/FixedOffsetTimeZone.toString|toString(){}[0]
 
     final object Companion { // kotlinx.datetime/FixedOffsetTimeZone.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<kotlinx.datetime/FixedOffsetTimeZone> // kotlinx.datetime/FixedOffsetTimeZone.Companion.serializer|serializer(){}[0]

--- a/core/common/src/TimeZone.kt
+++ b/core/common/src/TimeZone.kt
@@ -9,6 +9,7 @@
 package kotlinx.datetime
 
 import kotlinx.serialization.Serializable
+import kotlinx.datetime.serializers.*
 import kotlin.time.Instant
 
 /**
@@ -56,7 +57,7 @@ import kotlin.time.Instant
  *
  * @sample kotlinx.datetime.test.samples.TimeZoneSamples.usage
  */
-public expect open class TimeZone {
+public open class TimeZone internal constructor() {
     /**
      * Returns the identifier string of the time zone.
      *
@@ -64,7 +65,8 @@ public expect open class TimeZone {
      *
      * @sample kotlinx.datetime.test.samples.TimeZoneSamples.id
      */
-    public val id: String
+    public open val id: String
+        get() = error("Should be overridden")
 
     /**
      * Finds the offset from UTC this time zone has at the specified [instant] of physical time.
@@ -77,7 +79,8 @@ public expect open class TimeZone {
      * @see TimeZone.offsetAt
      * @sample kotlinx.datetime.test.samples.TimeZoneSamples.offsetAt
      */
-    public fun offsetAt(instant: Instant): UtcOffset
+    public open fun offsetAt(instant: Instant): UtcOffset =
+        error("Should be overridden")
 
     /**
      * Returns the [offset information][LocalDateTimeOffsetInfo] corresponding to the given [dateTime] in this time zone.
@@ -89,14 +92,16 @@ public expect open class TimeZone {
      *
      * @sample kotlinx.datetime.test.samples.TimeZoneSamples.offsetInfoFor
      */
-    public fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo
+    public open fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
+        error("Should be overridden")
 
     /**
      * Equivalent to [id].
      *
      * @sample kotlinx.datetime.test.samples.TimeZoneSamples.equalsSample
      */
-    public override fun toString(): String
+    public override fun toString(): String =
+        error("Should be overridden")
 
     /**
      * Compares this time zone to the other one.
@@ -106,7 +111,11 @@ public expect open class TimeZone {
      *
      * @sample kotlinx.datetime.test.samples.TimeZoneSamples.equalsSample
      */
-    public override fun equals(other: Any?): Boolean
+    public override fun equals(other: Any?): Boolean =
+        error("Should be overridden")
+
+    public override fun hashCode(): Int =
+        error("Should be overridden")
 
     public companion object {
         /**
@@ -116,7 +125,7 @@ public expect open class TimeZone {
          *
          * @sample kotlinx.datetime.test.samples.TimeZoneSamples.utc
          */
-        public val UTC: FixedOffsetTimeZone
+        public val UTC: FixedOffsetTimeZone get() = UtcImpl
 
         /**
          * Equivalent to [TimeZoneContext.System.currentTimeZone].
@@ -125,7 +134,8 @@ public expect open class TimeZone {
             "Use TimeZoneContext.System.currentTimeZone instead",
             ReplaceWith("TimeZoneContext.System.currentTimeZone()")
         )
-        public fun currentSystemDefault(): TimeZone
+        public fun currentSystemDefault(): TimeZone =
+            TimeZoneContext.System.currentTimeZone()
 
         /**
          * Equivalent to [TimeZoneContext.System.get].
@@ -134,7 +144,8 @@ public expect open class TimeZone {
             "Use TimeZoneContext.System.get instead",
             ReplaceWith("TimeZoneContext.System.get(zoneId)")
         )
-        public fun of(zoneId: String): TimeZone
+        public fun of(zoneId: String): TimeZone =
+            TimeZoneContext.System.get(zoneId)
 
         /**
          * Equivalent to [TimeZoneContext.System.availableZoneIds].
@@ -143,7 +154,8 @@ public expect open class TimeZone {
             "Use TimeZoneContext.System.availableZoneIds instead",
             ReplaceWith("TimeZoneContext.System.availableZoneIds()")
         )
-        public val availableZoneIds: Set<String>
+        public val availableZoneIds: Set<String> get() =
+            TimeZoneContext.System.availableZoneIds()
 
         /** @suppress */
         @Deprecated(
@@ -152,7 +164,9 @@ public expect open class TimeZone {
                     "Please serialize the string id instead.",
             level = DeprecationLevel.WARNING,
         )
-        public fun serializer(): kotlinx.serialization.KSerializer<TimeZone>
+        @Suppress("DEPRECATION")
+        public fun serializer(): kotlinx.serialization.KSerializer<TimeZone> =
+            TimeZoneSerializer
     }
 
     /**
@@ -162,7 +176,7 @@ public expect open class TimeZone {
         "Pass the time zone as a context parameter using the `context(timeZone) { }` syntax",
         level = DeprecationLevel.HIDDEN,
     )
-    public fun Instant.toLocalDateTime(): LocalDateTime
+    public fun Instant.toLocalDateTime(): LocalDateTime = toLocalDateTime(this@TimeZone)
 
     /**
      * Return the civil datetime value that this instant has in the time zone provided as an implicit receiver.
@@ -179,7 +193,7 @@ public expect open class TimeZone {
         level = DeprecationLevel.WARNING,
         replaceWith = ReplaceWith("this.toStdlibInstant().toLocalDateTime()")
     )
-    public fun kotlinx.datetime.Instant.toLocalDateTime(): LocalDateTime
+    public fun kotlinx.datetime.Instant.toLocalDateTime(): LocalDateTime = toStdlibInstant().toLocalDateTime()
 
     /**
      * @suppress
@@ -190,13 +204,17 @@ public expect open class TimeZone {
                 "and pass the time zone as a context parameter using the `context(timeZone) { }` syntax",
         level = DeprecationLevel.HIDDEN,
     )
-    public fun LocalDateTime.toInstant(youShallNotPass: OverloadMarker = OverloadMarker.INSTANCE): Instant
+    public fun LocalDateTime.toInstant(youShallNotPass: OverloadMarker = OverloadMarker.INSTANCE): Instant =
+        toInstant(this@TimeZone, TransitionHandler.USE_OFFSET_BEFORE)
 
     @PublishedApi
     @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "DEPRECATION")
     @kotlin.internal.LowPriorityInOverloadResolution
-    internal fun LocalDateTime.toInstant(): kotlinx.datetime.Instant
+    internal fun LocalDateTime.toInstant(): kotlinx.datetime.Instant =
+        toInstant(this@TimeZone).toDeprecatedInstant()
 }
+
+internal expect val UtcImpl: FixedOffsetTimeZone
 
 /**
  * A time zone that is known to always have the same offset from UTC.
@@ -607,4 +625,3 @@ internal fun localDateTimeToInstantLenient(
         handler.resolveDateTime(dateTime, offsetInfo, actualPreferred)
     }
 }
-

--- a/core/common/src/TimeZone.kt
+++ b/core/common/src/TimeZone.kt
@@ -125,7 +125,7 @@ public open class TimeZone internal constructor() {
          *
          * @sample kotlinx.datetime.test.samples.TimeZoneSamples.utc
          */
-        public val UTC: FixedOffsetTimeZone get() = UtcImpl
+        public val UTC: FixedOffsetTimeZone = FixedOffsetTimeZone(UtcOffset.ZERO, "UTC")
 
         /**
          * Equivalent to [TimeZoneContext.System.currentTimeZone].
@@ -214,7 +214,6 @@ public open class TimeZone internal constructor() {
         toInstant(this@TimeZone).toDeprecatedInstant()
 }
 
-internal expect val UtcImpl: FixedOffsetTimeZone
 
 /**
  * A time zone that is known to always have the same offset from UTC.
@@ -231,23 +230,36 @@ internal expect val UtcImpl: FixedOffsetTimeZone
  *
  * @sample kotlinx.datetime.test.samples.TimeZoneSamples.FixedOffsetTimeZoneSamples.casting
  */
-public expect class FixedOffsetTimeZone : TimeZone {
-    /**
-     * Constructs a time zone with the fixed [offset] from UTC.
-     *
-     * @sample kotlinx.datetime.test.samples.TimeZoneSamples.FixedOffsetTimeZoneSamples.constructorFunction
-     */
-    public constructor(offset: UtcOffset)
-
+public class FixedOffsetTimeZone internal constructor(
     /**
      * The constant offset from UTC that this time zone has.
      *
      * @sample kotlinx.datetime.test.samples.TimeZoneSamples.FixedOffsetTimeZoneSamples.offset
      */
-    public val offset: UtcOffset
+    public val offset: UtcOffset,
+    override val id: String
+): TimeZone() {
+    /**
+     * Constructs a time zone with the fixed [offset] from UTC.
+     *
+     * @sample kotlinx.datetime.test.samples.TimeZoneSamples.FixedOffsetTimeZoneSamples.constructorFunction
+     */
+    public constructor(offset: UtcOffset) : this(offset, offset.toString())
 
     @Deprecated("Use offset.totalSeconds", ReplaceWith("offset.totalSeconds"))
-    public val totalSeconds: Int
+    public val totalSeconds: Int get() = offset.totalSeconds
+
+    override fun offsetAt(instant: Instant): UtcOffset = offset
+
+    override fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
+        LocalDateTimeOffsetInfo.Regular(offset)
+
+    override fun toString(): String = id
+
+    override fun equals(other: Any?): Boolean =
+        this === other || other is FixedOffsetTimeZone && this.id == other.id
+
+    override fun hashCode(): Int = id.hashCode()
 
     /** @suppress */
     public companion object {
@@ -258,7 +270,18 @@ public expect class FixedOffsetTimeZone : TimeZone {
                     "Please serialize the string id instead.",
             level = DeprecationLevel.WARNING,
         )
-        public fun serializer(): kotlinx.serialization.KSerializer<FixedOffsetTimeZone>
+        @Suppress("DEPRECATION")
+        public fun serializer(): kotlinx.serialization.KSerializer<FixedOffsetTimeZone> =
+            FixedOffsetTimeZoneSerializer
+
+        internal fun withSpecificName(offset: UtcOffset, id: String): FixedOffsetTimeZone =
+            FixedOffsetTimeZone(offset, id)
+
+        internal fun withSpecificPrefix(offset: UtcOffset, prefix: String): FixedOffsetTimeZone =
+            when (offset.totalSeconds) {
+                0 -> withSpecificName(offset, prefix)
+                else -> withSpecificName(offset, "$prefix$offset")
+            }
     }
 }
 

--- a/core/common/src/internal/tz/RuleBasedTimeZone.kt
+++ b/core/common/src/internal/tz/RuleBasedTimeZone.kt
@@ -5,11 +5,14 @@
 
 package kotlinx.datetime.internal
 
-import kotlinx.datetime.*
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalDateTimeOffsetInfo
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.UtcOffset
 import kotlin.time.Instant
 
 internal class RuleBasedTimeZone(
-    private val tzid: TimeZoneRules, override val id: String, val origin: Any?, overloadResolver: Unit
+    private val tzid: TimeZoneRules, override val id: String, val origin: Any?
 ): TimeZone() {
     override fun offsetAt(instant: Instant): UtcOffset = tzid.infoAtInstant(instant)
 
@@ -23,6 +26,3 @@ internal class RuleBasedTimeZone(
 
     override fun toString(): String = id
 }
-
-internal actual fun RuleBasedTimeZone(tzid: TimeZoneRules, id: String, origin: Any?): TimeZone =
-    RuleBasedTimeZone(tzid, id, origin, Unit)

--- a/core/common/src/internal/tz/systemTimeZoneContext.kt
+++ b/core/common/src/internal/tz/systemTimeZoneContext.kt
@@ -15,10 +15,3 @@ internal expect fun currentSystemDefaultTimeZone(): TimeZone
 internal expect val systemTimeZoneIdProvider: TimeZoneIdProvider
 
 internal expect fun RuleBasedTimeZone(tzid: TimeZoneRules, id: String, origin: Any?): TimeZone
-internal expect fun FixedOffsetTimeZone.Companion.withSpecificName(offset: UtcOffset, id: String): FixedOffsetTimeZone
-
-internal fun FixedOffsetTimeZone.Companion.withSpecificPrefix(offset: UtcOffset, prefix: String): FixedOffsetTimeZone =
-    when (offset.totalSeconds) {
-        0 -> FixedOffsetTimeZone.withSpecificName(offset, prefix)
-        else -> FixedOffsetTimeZone.withSpecificName(offset, "$prefix$offset")
-    }

--- a/core/common/src/internal/tz/systemTimeZoneContext.kt
+++ b/core/common/src/internal/tz/systemTimeZoneContext.kt
@@ -13,5 +13,3 @@ internal val systemTimezoneDatabase: TimeZoneDatabase =
 internal expect val timeZoneDatabaseImpl: TimeZoneDatabase
 internal expect fun currentSystemDefaultTimeZone(): TimeZone
 internal expect val systemTimeZoneIdProvider: TimeZoneIdProvider
-
-internal expect fun RuleBasedTimeZone(tzid: TimeZoneRules, id: String, origin: Any?): TimeZone

--- a/core/commonJs/src/internal/Platform.kt
+++ b/core/commonJs/src/internal/Platform.kt
@@ -138,6 +138,8 @@ private object SystemTimeZone: TimeZone() {
         }
     }
 
+    override fun toString(): String = "SYSTEM"
+
     override fun equals(other: Any?): Boolean = other === this
 
     override fun hashCode(): Int = id.hashCode()

--- a/core/commonKotlin/src/TimeZone.kt
+++ b/core/commonKotlin/src/TimeZone.kt
@@ -10,92 +10,9 @@ package kotlinx.datetime
 
 import kotlinx.datetime.internal.*
 import kotlinx.datetime.serializers.*
-import kotlinx.serialization.Serializable
 import kotlin.time.Instant
 
-public actual open class TimeZone internal constructor() {
-
-    public actual companion object {
-        public actual val UTC: FixedOffsetTimeZone = FixedOffsetTimeZone(UtcOffset.ZERO, "UTC")
-
-        @Deprecated(
-            "Use TimeZoneContext.System.currentTimeZone() instead",
-            ReplaceWith("TimeZoneContext.System.currentTimeZone()")
-        )
-        public actual fun currentSystemDefault(): TimeZone =
-            TimeZoneContext.System.currentTimeZone()
-
-        @Deprecated(
-            "Use TimeZoneContext.System.get() instead",
-            ReplaceWith("TimeZoneContext.System.get(zoneId)")
-        )
-        public actual fun of(zoneId: String): TimeZone = TimeZoneContext.System.get(zoneId)
-
-        @Deprecated(
-            "Use TimeZoneContext.System.availableZoneIds() instead",
-            ReplaceWith("TimeZoneContext.System.availableZoneIds()")
-        )
-        public actual val availableZoneIds: Set<String>
-            get() = TimeZoneContext.System.availableZoneIds()
-
-        @Deprecated(
-            "Serializing TimeZone is discouraged, " +
-                    "as deserialization can fail depending on the configuration. " +
-                    "Please serialize the string id instead.",
-            level = DeprecationLevel.WARNING,
-        )
-        @Suppress("DEPRECATION")
-        public actual fun serializer(): kotlinx.serialization.KSerializer<TimeZone> = TimeZoneSerializer
-    }
-
-    public actual open val id: String
-        get() = error("Should be overridden")
-
-    @Deprecated(
-        "Pass the time zone as a context parameter using the `context(timeZone) { }` syntax",
-        level = DeprecationLevel.HIDDEN,
-    )
-    public actual fun Instant.toLocalDateTime(): LocalDateTime = toLocalDateTime(this@TimeZone)
-
-    @Suppress("DEPRECATION_ERROR")
-    @Deprecated(
-        "Explicitly pass a TransitionHandler to `toInstant` calls " +
-                "and pass the time zone as a context parameter using the `context(timeZone) { }` syntax",
-        level = DeprecationLevel.HIDDEN,
-        replaceWith = ReplaceWith("this.toInstant(TransitionHandler.USE_OFFSET_BEFORE)")
-    )
-    public actual fun LocalDateTime.toInstant(youShallNotPass: OverloadMarker): Instant =
-        toInstant(TransitionHandler.USE_OFFSET_BEFORE)
-
-    @Suppress("DEPRECATION")
-    @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-        level = DeprecationLevel.WARNING,
-        replaceWith = ReplaceWith("this.toStdlibInstant().toLocalDateTime()")
-    )
-    public actual fun kotlinx.datetime.Instant.toLocalDateTime(): LocalDateTime =
-        toStdlibInstant().toLocalDateTime()
-
-    @PublishedApi
-    @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "DEPRECATION")
-    @kotlin.internal.LowPriorityInOverloadResolution
-    internal actual fun LocalDateTime.toInstant(): kotlinx.datetime.Instant =
-        toInstant(this@TimeZone).toDeprecatedInstant()
-
-    public actual open fun offsetAt(instant: Instant): UtcOffset = error("Should be overridden")
-
-    public actual open fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo = error("Should be overridden")
-
-    internal open fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset? = null): Instant =
-        localDateTimeToInstantLenient(dateTime, this, TransitionHandler.USE_OFFSET_BEFORE, preferred)
-
-    actual override fun equals(other: Any?): Boolean =
-        error("Should be overridden")
-
-    override fun hashCode(): Int =
-        error("Should be overridden")
-
-    actual override fun toString(): String = id
-}
+internal actual val UtcImpl: FixedOffsetTimeZone = FixedOffsetTimeZone(UtcOffset.ZERO, "UTC")
 
 public actual class FixedOffsetTimeZone internal constructor(public actual val offset: UtcOffset, override val id: String) : TimeZone() {
 
@@ -109,8 +26,7 @@ public actual class FixedOffsetTimeZone internal constructor(public actual val o
     override fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
         LocalDateTimeOffsetInfo.Regular(offset)
 
-    override fun localDateTimeToInstant(dateTime: LocalDateTime, preferred: UtcOffset?): Instant =
-        dateTime.toInstant(offset)
+    override fun toString(): String = id
 
     override fun equals(other: Any?): Boolean =
         this === other || other is FixedOffsetTimeZone && this.id == other.id
@@ -153,9 +69,8 @@ internal fun Instant.toLocalDateTimeImpl(offset: UtcOffset): LocalDateTime {
 
 @Suppress("DEPRECATION_ERROR")
 public actual fun LocalDateTime.toInstant(timeZone: TimeZone, youShallNotPass: OverloadMarker): Instant =
-    timeZone.localDateTimeToInstant(this)
+    localDateTimeToInstantLenient(this, timeZone, TransitionHandler.USE_OFFSET_BEFORE, null)
 
 @Suppress("DEPRECATION_ERROR")
 public actual fun LocalDateTime.toInstant(offset: UtcOffset, youShallNotPass: OverloadMarker): Instant =
     Instant.fromEpochSeconds(this.toEpochSecond(offset), this.nanosecond)
-

--- a/core/commonKotlin/src/TimeZone.kt
+++ b/core/commonKotlin/src/TimeZone.kt
@@ -12,42 +12,6 @@ import kotlinx.datetime.internal.*
 import kotlinx.datetime.serializers.*
 import kotlin.time.Instant
 
-internal actual val UtcImpl: FixedOffsetTimeZone = FixedOffsetTimeZone(UtcOffset.ZERO, "UTC")
-
-public actual class FixedOffsetTimeZone internal constructor(public actual val offset: UtcOffset, override val id: String) : TimeZone() {
-
-    public actual constructor(offset: UtcOffset) : this(offset, offset.toString())
-
-    @Deprecated("Use offset.totalSeconds", ReplaceWith("offset.totalSeconds"))
-    public actual val totalSeconds: Int get() = offset.totalSeconds
-
-    override fun offsetAt(instant: Instant): UtcOffset = offset
-
-    override fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
-        LocalDateTimeOffsetInfo.Regular(offset)
-
-    override fun toString(): String = id
-
-    override fun equals(other: Any?): Boolean =
-        this === other || other is FixedOffsetTimeZone && this.id == other.id
-
-    override fun hashCode(): Int = id.hashCode()
-
-    /** @suppress */
-    public actual companion object {
-        /** @suppress */
-        @Deprecated(
-            "Serializing FixedOffsetTimeZone is discouraged, " +
-                    "as deserialization can fail or return a non-fixed-offset zone depending on the configuration. " +
-                    "Please serialize the string id instead.",
-            level = DeprecationLevel.WARNING,
-        )
-        @Suppress("DEPRECATION")
-        public actual fun serializer(): kotlinx.serialization.KSerializer<FixedOffsetTimeZone> =
-            FixedOffsetTimeZoneSerializer
-    }
-}
-
 @PublishedApi
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 internal fun TimeZone.offsetAt(instant: Instant): UtcOffset = offsetAt(instant) // member shadows the extension

--- a/core/commonKotlin/src/internal/systemTimeZoneContext.kt
+++ b/core/commonKotlin/src/internal/systemTimeZoneContext.kt
@@ -26,6 +26,3 @@ internal class RuleBasedTimeZone(
 
 internal actual fun RuleBasedTimeZone(tzid: TimeZoneRules, id: String, origin: Any?): TimeZone =
     RuleBasedTimeZone(tzid, id, origin, Unit)
-
-internal actual fun FixedOffsetTimeZone.Companion.withSpecificName(offset: UtcOffset, id: String): FixedOffsetTimeZone =
-    FixedOffsetTimeZone(offset, id)

--- a/core/commonKotlin/test/ThreeTenBpTimeZoneTest.kt
+++ b/core/commonKotlin/test/ThreeTenBpTimeZoneTest.kt
@@ -33,14 +33,14 @@ class ThreeTenBpTimeZoneTest {
         val t1 = LocalDateTime(2020, 3, 29, 2, 14, 17, 201)
         val t2 = LocalDateTime(2020, 3, 29, 3, 14, 17, 201)
         val tz = TimeZoneContext.System.get("Europe/Berlin")
-        assertEquals(tz.localDateTimeToInstant(t1), tz.localDateTimeToInstant(t2))
+        assertEquals(t1.toInstant(tz), t2.toInstant(tz, TransitionHandler.USE_OFFSET_BEFORE))
     }
 
     @Test
     fun overlappingLocalTime() {
         val t = LocalDateTime(2007, 10, 28, 2, 30, 0, 0)
         val zone = TimeZoneContext.System.get("Europe/Paris")
-        assertEquals(t.toInstant(UtcOffset(hours = 2)), zone.localDateTimeToInstant(t))
+        assertEquals(t.toInstant(UtcOffset(hours = 2)), t.toInstant(zone, TransitionHandler.USE_OFFSET_BEFORE))
     }
 
 }

--- a/core/jvm/src/Converters.kt
+++ b/core/jvm/src/Converters.kt
@@ -76,7 +76,6 @@ public fun java.time.Period.toKotlinDatePeriod(): DatePeriod = DatePeriod(this.y
  */
 public fun TimeZone.toJavaZoneId(): java.time.ZoneId = when (this) {
     is JvmTimeZone -> actualZoneId
-    is FixedOffsetTimeZone -> actualZoneId
     else -> java.time.ZoneId.of(this.id)
 }
 

--- a/core/jvm/src/TimeZoneJvm.kt
+++ b/core/jvm/src/TimeZoneJvm.kt
@@ -8,8 +8,6 @@
 
 package kotlinx.datetime
 
-import kotlinx.datetime.internal.TimeZoneRules
-import kotlinx.datetime.serializers.*
 import java.time.DateTimeException
 import java.time.ZoneId
 import java.time.ZoneOffset as jtZoneOffset
@@ -87,20 +85,4 @@ internal class JvmTimeZone(val actualZoneId: ZoneId) : TimeZone() {
     override fun hashCode(): Int = actualZoneId.hashCode()
 
     override fun toString(): String = actualZoneId.toString()
-}
-
-internal class RuleBasedTimeZone(
-    private val tzid: TimeZoneRules, override val id: String, val origin: Any?, overloadResolver: Unit
-): TimeZone() {
-    override fun offsetAt(instant: Instant): UtcOffset = tzid.infoAtInstant(instant)
-
-    override fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
-        tzid.infoAtDatetime(dateTime)
-
-    override fun equals(other: Any?): Boolean =
-        other is RuleBasedTimeZone && id == other.id && origin == other.origin
-
-    override fun hashCode(): Int = id.hashCode()
-
-    override fun toString(): String = id
 }

--- a/core/jvm/src/TimeZoneJvm.kt
+++ b/core/jvm/src/TimeZoneJvm.kt
@@ -10,7 +10,6 @@ package kotlinx.datetime
 
 import kotlinx.datetime.internal.TimeZoneRules
 import kotlinx.datetime.serializers.*
-import kotlinx.datetime.toInstant
 import java.time.DateTimeException
 import java.time.ZoneId
 import java.time.ZoneOffset as jtZoneOffset
@@ -18,99 +17,13 @@ import kotlin.time.Instant
 import kotlin.time.toJavaInstant
 import kotlin.time.toKotlinInstant
 
-public actual open class TimeZone internal constructor() {
-    public actual open val id: String get() =
-        error("Should be overridden")
-
-    public actual open fun offsetAt(instant: Instant): UtcOffset =
-        error("Should be overridden")
-
-    public actual open fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
-        error("Should be overridden")
-
-    // experimental member-extensions
-    @Deprecated(
-        "Pass the time zone as a context parameter using the `context(timeZone) { }` syntax",
-        level = DeprecationLevel.HIDDEN,
-    )
-    public actual fun Instant.toLocalDateTime(): LocalDateTime = toLocalDateTime(this@TimeZone)
-
-    @Suppress("DEPRECATION_ERROR")
-    @Deprecated(
-        "Explicitly pass a TransitionHandler to `toInstant` calls " +
-                "and pass the time zone as a context parameter using the `context(timeZone) { }` syntax",
-        level = DeprecationLevel.HIDDEN,
-        replaceWith = ReplaceWith("this.toInstant(TransitionHandler.USE_OFFSET_BEFORE)")
-    )
-    public actual fun LocalDateTime.toInstant(youShallNotPass: OverloadMarker): Instant =
-        toInstant(this@TimeZone, TransitionHandler.USE_OFFSET_BEFORE)
-
-    @Suppress("DEPRECATION")
-    @Deprecated("kotlinx.datetime.Instant is superseded by kotlin.time.Instant",
-        level = DeprecationLevel.WARNING,
-        replaceWith = ReplaceWith("this.toStdlibInstant().toLocalDateTime()")
-    )
-    public actual fun kotlinx.datetime.Instant.toLocalDateTime(): LocalDateTime =
-        toStdlibInstant().toLocalDateTime()
-
-    @PublishedApi
-    @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "DEPRECATION")
-    @kotlin.internal.LowPriorityInOverloadResolution
-    internal actual fun LocalDateTime.toInstant(): kotlinx.datetime.Instant =
-        toInstant(this@TimeZone).toDeprecatedInstant()
-
-    actual override fun equals(other: Any?): Boolean =
-        error("Should be overridden")
-
-    override fun hashCode(): Int =
-        error("Should be overridden")
-
-    actual override fun toString(): String =
-        error("Should be overridden")
-
-    public actual companion object {
-        public actual val UTC: FixedOffsetTimeZone =
-            FixedOffsetTimeZone(UtcOffset.ZERO, ZoneId.of("UTC"))
-
-        @Deprecated(
-            "Use TimeZoneContext.System.currentTimeZone() instead",
-            ReplaceWith("TimeZoneContext.System.currentTimeZone()")
-        )
-        public actual fun currentSystemDefault(): TimeZone =
-            TimeZoneContext.System.currentTimeZone()
-
-        @Deprecated(
-            "Use TimeZoneContext.System.get() instead",
-            ReplaceWith("TimeZoneContext.System.get(zoneId)")
-        )
-        public actual fun of(zoneId: String): TimeZone =
-            TimeZoneContext.System.get(zoneId)
-
-        @Deprecated(
-            "Use TimeZoneContext.System.availableZoneIds() instead",
-            ReplaceWith("TimeZoneContext.System.availableZoneIds()")
-        )
-        public actual val availableZoneIds: Set<String> get() =
-            TimeZoneContext.System.availableZoneIds()
-
-        internal fun ofZone(zoneId: ZoneId): TimeZone = when {
-            zoneId is jtZoneOffset ->
-                FixedOffsetTimeZone(UtcOffset(zoneId))
-            zoneId.isFixedOffset ->
-                FixedOffsetTimeZone(UtcOffset(zoneId.normalized() as jtZoneOffset), zoneId)
-            else ->
-                JvmTimeZone(zoneId)
-        }
-
-        @Deprecated(
-            "Serializing TimeZone is discouraged, " +
-                    "as deserialization can fail depending on the configuration. " +
-                    "Please serialize the string id instead.",
-            level = DeprecationLevel.WARNING,
-        )
-        @Suppress("DEPRECATION")
-        public actual fun serializer(): kotlinx.serialization.KSerializer<TimeZone> = TimeZoneSerializer
-    }
+internal fun TimeZone.Companion.ofZone(zoneId: ZoneId): TimeZone = when {
+    zoneId is jtZoneOffset ->
+        FixedOffsetTimeZone(UtcOffset(zoneId))
+    zoneId.isFixedOffset ->
+        FixedOffsetTimeZone(UtcOffset(zoneId.normalized() as jtZoneOffset), zoneId)
+    else ->
+        JvmTimeZone(zoneId)
 }
 
 // Workaround for https://issuetracker.google.com/issues/203956057
@@ -118,9 +31,11 @@ private val ZoneId.isFixedOffset: Boolean
     get() = try {
         // On older Android versions, this can throw even though it shouldn't
         rules.isFixedOffset
-    } catch (e: ArrayIndexOutOfBoundsException) {
+    } catch (_: ArrayIndexOutOfBoundsException) {
         false // Happens for America/Costa_Rica, Africa/Cairo, Egypt
     }
+
+internal actual val UtcImpl: FixedOffsetTimeZone = FixedOffsetTimeZone(UtcOffset.ZERO, ZoneId.of("UTC"))
 
 public actual class FixedOffsetTimeZone
 internal constructor(public actual val offset: UtcOffset, internal val actualZoneId: ZoneId): TimeZone() {

--- a/core/jvm/src/TimeZoneJvm.kt
+++ b/core/jvm/src/TimeZoneJvm.kt
@@ -21,7 +21,7 @@ internal fun TimeZone.Companion.ofZone(zoneId: ZoneId): TimeZone = when {
     zoneId is jtZoneOffset ->
         FixedOffsetTimeZone(UtcOffset(zoneId))
     zoneId.isFixedOffset ->
-        FixedOffsetTimeZone(UtcOffset(zoneId.normalized() as jtZoneOffset), zoneId)
+        FixedOffsetTimeZone(UtcOffset(zoneId.normalized() as jtZoneOffset), zoneId.toString())
     else ->
         JvmTimeZone(zoneId)
 }
@@ -34,45 +34,6 @@ private val ZoneId.isFixedOffset: Boolean
     } catch (_: ArrayIndexOutOfBoundsException) {
         false // Happens for America/Costa_Rica, Africa/Cairo, Egypt
     }
-
-internal actual val UtcImpl: FixedOffsetTimeZone = FixedOffsetTimeZone(UtcOffset.ZERO, ZoneId.of("UTC"))
-
-public actual class FixedOffsetTimeZone
-internal constructor(public actual val offset: UtcOffset, internal val actualZoneId: ZoneId): TimeZone() {
-    public actual constructor(offset: UtcOffset) : this(offset, offset.zoneOffset)
-
-    @Deprecated("Use offset.totalSeconds", ReplaceWith("offset.totalSeconds"))
-    public actual val totalSeconds: Int get() = offset.totalSeconds
-
-    /** @suppress */
-    public actual companion object {
-        /** @suppress */
-        @Deprecated(
-            "Serializing FixedOffsetTimeZone is discouraged, " +
-                    "as deserialization can fail or return a non-fixed-offset zone depending on the configuration. " +
-                    "Please serialize the string id instead.",
-            level = DeprecationLevel.WARNING,
-        )
-        @Suppress("DEPRECATION")
-        public actual fun serializer(): kotlinx.serialization.KSerializer<FixedOffsetTimeZone> =
-            FixedOffsetTimeZoneSerializer
-    }
-
-    override val id: String
-        get() = actualZoneId.id
-
-    override fun offsetAt(instant: Instant): UtcOffset = offset
-
-    override fun offsetInfoFor(dateTime: LocalDateTime): LocalDateTimeOffsetInfo =
-        LocalDateTimeOffsetInfo.Regular(offset)
-
-    override fun equals(other: Any?): Boolean =
-        other is FixedOffsetTimeZone && actualZoneId == other.actualZoneId
-
-    override fun hashCode(): Int = actualZoneId.hashCode()
-
-    override fun toString(): String = actualZoneId.toString()
-}
 
 // compatibility with 0.8.0
 @PublishedApi

--- a/core/jvm/src/internal/systemTimeZoneContextJvm.kt
+++ b/core/jvm/src/internal/systemTimeZoneContextJvm.kt
@@ -12,6 +12,7 @@ import kotlinx.datetime.RuleBasedTimeZone
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.TimeZoneDatabase
 import kotlinx.datetime.UtcOffset
+import kotlinx.datetime.ofZone
 import java.time.DateTimeException
 import java.time.ZoneId
 import java.time.ZoneId.getAvailableZoneIds

--- a/core/jvm/src/internal/systemTimeZoneContextJvm.kt
+++ b/core/jvm/src/internal/systemTimeZoneContextJvm.kt
@@ -44,6 +44,3 @@ internal actual val systemTimeZoneIdProvider: TimeZoneIdProvider = object: TimeZ
 
 internal actual fun RuleBasedTimeZone(tzid: TimeZoneRules, id: String, origin: Any?): TimeZone =
     RuleBasedTimeZone(tzid, id, origin, Unit)
-
-internal actual fun FixedOffsetTimeZone.Companion.withSpecificName(offset: UtcOffset, id: String): FixedOffsetTimeZone =
-    FixedOffsetTimeZone(offset, ZoneId.of(id))

--- a/core/jvm/src/internal/systemTimeZoneContextJvm.kt
+++ b/core/jvm/src/internal/systemTimeZoneContextJvm.kt
@@ -5,13 +5,10 @@
 
 package kotlinx.datetime.internal
 
-import kotlinx.datetime.FixedOffsetTimeZone
 import kotlinx.datetime.TimeZoneIdProvider
 import kotlinx.datetime.IllegalTimeZoneException
-import kotlinx.datetime.RuleBasedTimeZone
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.TimeZoneDatabase
-import kotlinx.datetime.UtcOffset
 import kotlinx.datetime.ofZone
 import java.time.DateTimeException
 import java.time.ZoneId
@@ -41,6 +38,3 @@ internal actual val timeZoneDatabaseImpl: TimeZoneDatabase = object: TimeZoneDat
 internal actual val systemTimeZoneIdProvider: TimeZoneIdProvider = object: TimeZoneIdProvider {
     override fun currentTimeZoneId(): String = systemDefault().id
 }
-
-internal actual fun RuleBasedTimeZone(tzid: TimeZoneRules, id: String, origin: Any?): TimeZone =
-    RuleBasedTimeZone(tzid, id, origin, Unit)


### PR DESCRIPTION
After all the changes, `TimeZone`'s implementation isn't meaningfully different between the targets. This change moves the `TimeZone`, `FixedOffsetTimeZone`, and the internal `RuleBasedTimeZone` to `common`.

For the most part, this change is entirely equivalent and is strictly code simplification.

The one place where the structure of a class changed was `FixedOffsetTimeZone`. Before, on the JVM, this class used to store a `ZoneId`, which allowed extremely fast conversions to `ZoneId` (merely by unwrapping the value already stored there). In exchange for this speedup, every creation of a `FixedOffsetTimeZone` through the non-Java timezone database was slower because of needing to parse `ZoneId` eagerly.